### PR TITLE
Test case

### DIFF
--- a/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64
+++ b/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64
@@ -1,0 +1,31 @@
+# RUN: llvm-mc -triple=x86_64-pc-win32 -filetype=obj -o %T/COFF_x86_64.o %s
+# RUN: llvm-rtdyld -triple=x86_64-pc-win32 -verify -check=%s %/T/COFF_x86_64.o
+        	.text
+	.def	 F;
+	.scl	2;
+	.type	32;
+	.endef
+	.globl	__real400921f9f01b866e
+	.section	.rdata,"dr",discard,__real400921f9f01b866e
+	.align	8
+__real400921f9f01b866e:
+	.quad	4614256650576692846     # double 3.1415899999999999
+	.text
+	.globl	F
+        .global inst1
+	.align	16, 0x90
+F:                                      # @F
+.Ltmp0:
+.seh_proc F
+# BB#0:                                 # %entry
+.Ltmp1:
+	.seh_endprologue
+# rtdyld-check: decode_operand(inst1, 4) = __real400921f9f01b866e - next_pc(inst1)
+inst1:
+	movsd	__real400921f9f01b866e(%rip), %xmm0 # xmm0 = mem[0],zero
+	retq
+.Leh_func_end0:
+.Ltmp2:
+	.seh_endproc
+
+


### PR DESCRIPTION
Incorporate more review feedback from LLVM, mostly raising fatal errors instead of asserting. 

Reworks the x86_64 relocation processing so that it can pass the dynamic linker's verification test. In particular be more careful about Address vs ObjAddress vs LoadedAddress.

Implement REL32 forms of relocations. Add a test case showing that the dynamic linker does the proper update for the basic REL32 relocation.

Stub out ADDR32NB until we understand how the dynamic linker is going to provide an image base and constrain sections to be within a 4GB region (for now these come from .pdata which we ignore since the jit makes its own version of this).

Fix some issues where the dynamic linker was confused by zero sized sections (we now claim they don't need to be loaded) or was too eager to look at .bss.

All tests pass on my good machine, though I'm less confident about this then I would like to be. Verified the dynamic linker test case by hand; will figure out how to run it from their harness and verify it works there too.
