### PR TITLE
Formatting fixes to match proper LLVM style, Rel32_N update

### DIFF
--- a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+++ b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
@@ -268,6 +268,11 @@ static bool isRequiredForExecution(const SectionRef &Section) {
     return ELFObj->getSectionFlags(Section) & ELF::SHF_ALLOC;
   if (auto *COFFObj = dyn_cast<object::COFFObjectFile>(Obj)) {
     const coff_section *CoffSection = COFFObj->getCOFFSection(Section);
+    // Avoid loading zero-sized COFF sections.
+    // In PE files, VirtualSize gives the section size, and SizeOfRawData
+    // may be zero for sections with content. In Obj files, SizeOfRawData 
+    // gives the section size, and VirtualSize is always zero. Hence
+    // the need to check for both cases below.
     bool HasContent = (CoffSection->VirtualSize > 0) 
       || (CoffSection->SizeOfRawData > 0);
     bool IsDiscardable = CoffSection->Characteristics &

--- a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
+++ b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
@@ -1,4 +1,4 @@
-//===-- RuntimeDyldCOFF.cpp - Run-time dynamic linker for MC-JIT -*- C++ -*-===//
+//===-- RuntimeDyldCOFF.cpp - Run-time dynamic linker for MC-JIT -*- C++ -*-==//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -27,15 +27,14 @@ namespace {
 class LoadedCOFFObjectInfo : public RuntimeDyld::LoadedObjectInfo {
 public:
   LoadedCOFFObjectInfo(RuntimeDyldImpl &RTDyld, unsigned BeginIdx,
-                        unsigned EndIdx)
-    : RuntimeDyld::LoadedObjectInfo(RTDyld, BeginIdx, EndIdx) {}
+                       unsigned EndIdx)
+      : RuntimeDyld::LoadedObjectInfo(RTDyld, BeginIdx, EndIdx) {}
 
   OwningBinary<ObjectFile>
   getObjectForDebug(const ObjectFile &Obj) const override {
     return OwningBinary<ObjectFile>();
   }
 };
-
 }
 
 namespace llvm {
@@ -46,7 +45,8 @@ llvm::RuntimeDyldCOFF::create(Triple::ArchType Arch, RTDyldMemoryManager *MM) {
   default:
     llvm_unreachable("Unsupported target for RuntimeDyldCOFF.");
     break;
-  case Triple::x86_64: return make_unique<RuntimeDyldCOFFX86_64>(MM);
+  case Triple::x86_64:
+    return make_unique<RuntimeDyldCOFFX86_64>(MM);
   }
 }
 
@@ -55,7 +55,7 @@ RuntimeDyldCOFF::loadObject(const object::ObjectFile &O) {
   unsigned SectionStartIdx, SectionEndIdx;
   std::tie(SectionStartIdx, SectionEndIdx) = loadObjectImpl(O);
   return llvm::make_unique<LoadedCOFFObjectInfo>(*this, SectionStartIdx,
-                                                SectionEndIdx);
+                                                 SectionEndIdx);
 }
 
 uint64_t RuntimeDyldCOFF::getSymbolOffset(const SymbolRef &Sym) {

--- a/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
+++ b/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
@@ -1,4 +1,4 @@
-//===-- RuntimeDyldCOFF.h - Run-time dynamic linker for MC-JIT ---*- C++ -*-===//
+//===-- RuntimeDyldCOFF.h - Run-time dynamic linker for MC-JIT ---*- C++ -*-==//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -28,15 +28,14 @@ namespace llvm {
 class RuntimeDyldCOFF : public RuntimeDyldImpl {
 
 public:
-
   std::unique_ptr<RuntimeDyld::LoadedObjectInfo>
   loadObject(const object::ObjectFile &Obj) override;
   bool isCompatibleFile(const object::ObjectFile &Obj) const override;
   static std::unique_ptr<RuntimeDyldCOFF> create(Triple::ArchType Arch,
-                                                  RTDyldMemoryManager *mm);
-protected:
+                                                 RTDyldMemoryManager *MM);
 
-  RuntimeDyldCOFF(RTDyldMemoryManager *mm) : RuntimeDyldImpl(mm) {}
+protected:
+  RuntimeDyldCOFF(RTDyldMemoryManager *MM) : RuntimeDyldImpl(MM) {}
   uint64_t getSymbolOffset(const SymbolRef &Sym);
 };
 

--- a/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
+++ b/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
@@ -25,16 +25,14 @@ namespace llvm {
 class RuntimeDyldCOFFX86_64 : public RuntimeDyldCOFF {
 
 private:
-
   // When a module is loaded we save the SectionID of the unwind
-  // sections in a table until we receive a request to register all 
+  // sections in a table until we receive a request to register all
   // unregisteredEH frame sections with the memory manager.
   SmallVector<SID, 2> UnregisteredEHFrameSections;
   SmallVector<SID, 2> RegisteredEHFrameSections;
 
 public:
-
-  RuntimeDyldCOFFX86_64(RTDyldMemoryManager *mm) : RuntimeDyldCOFF(mm) {}
+  RuntimeDyldCOFFX86_64(RTDyldMemoryManager *MM) : RuntimeDyldCOFF(MM) {}
 
   unsigned getMaxStubSize() override {
     return 6; // 2-byte jmp instruction + 32-bit relative address
@@ -42,16 +40,17 @@ public:
 
   void resolveRelocation(const RelocationEntry &RE, uint64_t Value) override;
 
-  relocation_iterator
-    processRelocationRef(unsigned SectionID, relocation_iterator RelI,
-    const ObjectFile &Obj, ObjSectionToIDMap &ObjSectionToID,
-    StubMap &Stubs) override;
+  relocation_iterator processRelocationRef(unsigned SectionID,
+                                           relocation_iterator RelI,
+                                           const ObjectFile &Obj,
+                                           ObjSectionToIDMap &ObjSectionToID,
+                                           StubMap &Stubs) override;
 
-  unsigned int getStubAlignment() override { return 1; }
+  unsigned getStubAlignment() override { return 1; }
   void registerEHFrames() override;
   void deregisterEHFrames() override;
   void finalizeLoad(const ObjectFile &Obj,
-    ObjSectionToIDMap &SectionMap) override;
+                    ObjSectionToIDMap &SectionMap) override;
 };
 
 } // end namespace llvm

--- a/lib/Object/COFFObjectFile.cpp
+++ b/lib/Object/COFFObjectFile.cpp
@@ -361,14 +361,10 @@ bool COFFObjectFile::isSectionData(DataRefImpl Ref) const {
 
 bool COFFObjectFile::isSectionBSS(DataRefImpl Ref) const {
   const coff_section *Sec = toSec(Ref);
-  return (Sec->Characteristics &
-    (COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA
-    | COFF::IMAGE_SCN_MEM_READ
-    | COFF::IMAGE_SCN_MEM_WRITE))
-    ==
-    (COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA
-    | COFF::IMAGE_SCN_MEM_READ
-    | COFF::IMAGE_SCN_MEM_WRITE);
+  const uint32_t BssFlags = COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA |
+                            COFF::IMAGE_SCN_MEM_READ |
+                            COFF::IMAGE_SCN_MEM_WRITE;
+  return (Sec->Characteristics & BssFlags) == BssFlags;
 }
 
 bool COFFObjectFile::isSectionVirtual(DataRefImpl Ref) const {


### PR DESCRIPTION
Rel32_n delta rework: fix sign and move the adjustment into resolveRelocation.
