### PR TITLE
Add calling conventions necessary when targeting the CLR on X86.

### DIFF
--- a/include/llvm/IR/CallingConv.h
+++ b/include/llvm/IR/CallingConv.h
@@ -69,6 +69,12 @@ namespace CallingConv {
     // (almost) all registers.
     PreserveAll = 15,
 
+    // CLR Virtual Dispatch Stub - Calling convention used for CLR virtual dispatch stub calls
+    CLR_VirtualDispatchStub = 16,
+
+    // CLR Secret Parameter - Calling convention used for CLR calls that accept a secret parameter
+    CLR_SecretParameter = 17,
+
     // Target - This is the start of the target-specific calling conventions,
     // e.g. fastcall and thiscall on X86.
     FirstTargetCC = 64,

--- a/lib/Target/X86/X86CallingConv.h
+++ b/lib/Target/X86/X86CallingConv.h
@@ -17,6 +17,7 @@
 
 #include "llvm/CodeGen/CallingConvLower.h"
 #include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Function.h"
 
 namespace llvm {
 
@@ -40,6 +41,15 @@ inline bool CC_X86_AnyReg_Error(unsigned &, MVT &, MVT &,
                    "stackmap and patchpoint intrinsics.");
   // gracefully fallback to X86 C calling convention on Release builds.
   return false;
+}
+
+inline bool hasCLRSecretParameterAttribute(unsigned ValNo, CCState &State) {
+  // CLR_SecretParameter is only valid when computing register allocation
+  // for function prologs.
+  assert(State.getCallOrPrologue() != ParmContext::Call);
+
+  const Function *Func = State.getMachineFunction().getFunction();
+  return Func->getAttributes().hasAttribute(ValNo + 1, "CLR_SecretParameter");
 }
 
 } // End llvm namespace

--- a/lib/Target/X86/X86CallingConv.td
+++ b/lib/Target/X86/X86CallingConv.td
@@ -420,6 +420,22 @@ def CC_X86_64_AnyReg : CallingConv<[
   CCCustom<"CC_X86_AnyReg_Error">
 ]>;
 
+def CC_X86_64_CLR_VirtualDispatchStub : CallingConv<[
+  // The first pointer-sized argument is passed in R11
+  CCIfType<[i64], CCAssignToReg<[R11]>>,
+
+  // Otherwise, drop to normal X86-64 CC
+  CCDelegateTo<CC_X86_64_C>
+]>;
+
+def CC_X86_64_CLR_SecretParameter : CallingConv<[
+  // The secret parameter is passed in R10
+  CCIf<"hasCLRSecretParameterAttribute(ValNo, State)", CCAssignToReg<[R10]>>,
+
+  // Otherwise, drop to normal X86-64 CC
+  CCDelegateTo<CC_X86_64_C>
+]>;
+
 //===----------------------------------------------------------------------===//
 // X86 C Calling Convention
 //===----------------------------------------------------------------------===//
@@ -642,6 +658,23 @@ def CC_Intel_OCL_BI : CallingConv<[
   CCDelegateTo<CC_X86_32_C>
 ]>;
 
+def CC_X86_32_CLR_VirtualDispatchStub : CallingConv<[
+  // The first pointer-sized argument is passed in EAX
+  CCIfType<[i32], CCAssignToReg<[EAX]>>,
+
+  // Otherwise, drop to normal X86-32 CC
+  CCDelegateTo<CC_X86_32_C>
+]>;
+
+def CC_X86_32_CLR_SecretParameter : CallingConv<[
+  // The secret parameter is passed in EAX
+  CCIf<"hasCLRSecretParameterAttribute(ValNo, State)", CCAssignToReg<[EAX]>>,
+
+  // Otherwise, drop to normal X86-64 CC
+  CCDelegateTo<CC_X86_64_C>
+]>;
+
+
 //===----------------------------------------------------------------------===//
 // X86 Root Argument Calling Conventions
 //===----------------------------------------------------------------------===//
@@ -654,6 +687,10 @@ def CC_X86_32 : CallingConv<[
   CCIfCC<"CallingConv::Fast", CCDelegateTo<CC_X86_32_FastCC>>,
   CCIfCC<"CallingConv::GHC", CCDelegateTo<CC_X86_32_GHC>>,
   CCIfCC<"CallingConv::HiPE", CCDelegateTo<CC_X86_32_HiPE>>,
+  CCIfCC<"CallingConv::CLR_VirtualDispatchStub",
+         CCDelegateTo<CC_X86_32_CLR_VirtualDispatchStub>>,
+  CCIfCC<"CallingConv::CLR_SecretParameter",
+         CCDelegateTo<CC_X86_32_CLR_SecretParameter>>,
 
   // Otherwise, drop to normal X86-32 CC
   CCDelegateTo<CC_X86_32_C>
@@ -668,6 +705,10 @@ def CC_X86_64 : CallingConv<[
   CCIfCC<"CallingConv::X86_64_Win64", CCDelegateTo<CC_X86_Win64_C>>,
   CCIfCC<"CallingConv::X86_64_SysV", CCDelegateTo<CC_X86_64_C>>,
   CCIfCC<"CallingConv::X86_VectorCall", CCDelegateTo<CC_X86_Win64_VectorCall>>,
+  CCIfCC<"CallingConv::CLR_VirtualDispatchStub",
+         CCDelegateTo<CC_X86_64_CLR_VirtualDispatchStub>>,
+  CCIfCC<"CallingConv::CLR_SecretParameter",
+         CCDelegateTo<CC_X86_64_CLR_SecretParameter>>,
 
   // Mingw64 and native Win64 use Win64 CC
   CCIfSubtarget<"isTargetWin64()", CCDelegateTo<CC_X86_Win64_C>>,


### PR DESCRIPTION
The CLR has (at least) two non-standard calling conventions that
are used by certain methods:
- The virtual dispatch stub calling convention, which takes a stub-specific
  parameter in a target-specific register
- The "secret parameter" calling convention, which takes an extra argument
  in a target-specific register

This adds support for these calling conventions to the X86 target. ARM and
others are yet to be done.
