### PR TITLE
Statepoints: Track Basepointers only if Required by the Runtime

### DIFF
--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -444,7 +444,7 @@ ModulePass *createPlaceSafepointsPass();
 // RewriteStatepointsForGC - Rewrite any gc.statepoints which do not yet have
 // explicit relocations to include explicit relocations.
 //
-FunctionPass *createRewriteStatepointsForGCPass();
+FunctionPass *createRewriteStatepointsForGCPass(bool TrackBasePointers = true);
 
 //===----------------------------------------------------------------------===//
 //


### PR DESCRIPTION
This change parametrizes the RewriteStatepointsForGC phase on whether
base-pointers should be explicitly tracked for each live GC-pointer.

Runtimes like the CLR do not require reporting the base-pointers for each
live managed pointer at gc-safepoints. When base-pointer tracking is
unnecessary, the gc-pointer -> base-pointer mapping is treated as identity.

This change does not affect code generation in LLVM tests, as there are
currently no clients for the configuration where base-pointers are not tracked.
