### PR TITLE
Add an intrinsic for calls that are GC transitions.

### DIFF
--- a/include/llvm/CodeGen/ISDOpcodes.h
+++ b/include/llvm/CodeGen/ISDOpcodes.h
@@ -694,6 +694,15 @@ namespace ISD {
     /// is the chain and the second operand is the alloca pointer.
     LIFETIME_START, LIFETIME_END,
 
+    /// GC_TRANSITION_START/GC_TRANSITION_END - These operators mark the
+    /// beginning and end of GC transition  sequence, and carry arbitrary
+    /// information that target might need for lowering.  The first operand is
+    /// a chain, the rest are specified by the target and not touched by the DAG
+    /// optimizers. GC_TRANSITION_START..GC_TRANSITION_END pairs may not be
+    /// nested.
+    GC_TRANSITION_START,
+    GC_TRANSITION_END,
+
     /// BUILTIN_OP_END - This must be the last enum value in this list.
     /// The target-specific pre-isel opcode values start here.
     BUILTIN_OP_END

--- a/include/llvm/IR/Intrinsics.td
+++ b/include/llvm/IR/Intrinsics.td
@@ -527,6 +527,9 @@ def int_experimental_patchpoint_i64 : Intrinsic<[llvm_i64_ty],
 def int_experimental_gc_statepoint : Intrinsic<[llvm_i32_ty],
                                [llvm_anyptr_ty, llvm_i32_ty,
                                 llvm_i32_ty, llvm_vararg_ty]>;
+def int_experimental_gc_transition : Intrinsic<[llvm_i32_ty],
+                               [llvm_anyptr_ty, llvm_i32_ty,
+                                llvm_i32_ty, llvm_vararg_ty]>;
 
 def int_experimental_gc_result   : Intrinsic<[llvm_any_ty], [llvm_i32_ty]>;
 def int_experimental_gc_relocate : Intrinsic<[llvm_anyptr_ty],

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -2011,6 +2011,7 @@ void SelectionDAGBuilder::visitInvoke(const InvokeInst &I) {
       visitPatchpoint(&I, LandingPad);
       break;
     case Intrinsic::experimental_gc_statepoint:
+    case Intrinsic::experimental_gc_transition:
       LowerStatepoint(ImmutableStatepoint(&I), LandingPad);
       break;
     }
@@ -5384,7 +5385,8 @@ SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I, unsigned Intrinsic) {
     visitPatchpoint(&I);
     return nullptr;
   }
-  case Intrinsic::experimental_gc_statepoint: {
+  case Intrinsic::experimental_gc_statepoint:
+  case Intrinsic::experimental_gc_transition: {
     visitStatepoint(I);
     return nullptr;
   }
@@ -5457,6 +5459,7 @@ SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I, unsigned Intrinsic) {
 
     return nullptr;
   }
+
   case Intrinsic::eh_begincatch:
   case Intrinsic::eh_endcatch:
     llvm_unreachable("begin/end catch intrinsics not lowered in codegen");

--- a/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -286,6 +286,8 @@ std::string SDNode::getOperationName(const SelectionDAG *G) const {
   case ISD::DEBUGTRAP:                  return "debugtrap";
   case ISD::LIFETIME_START:             return "lifetime.start";
   case ISD::LIFETIME_END:               return "lifetime.end";
+  case ISD::GC_TRANSITION_START:        return "gc_transition.start";
+  case ISD::GC_TRANSITION_END:          return "gc_transition.end";
 
   // Bit manipulation
   case ISD::BSWAP:                      return "bswap";

--- a/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
+++ b/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
@@ -38,8 +38,7 @@ STATISTIC(NumOfStatepoints, "Number of statepoint nodes encountered");
 STATISTIC(StatepointMaxSlotsRequired,
           "Maximum number of stack slots required for a singe statepoint");
 
-void
-StatepointLoweringState::startNewStatepoint(SelectionDAGBuilder &Builder) {
+void StatepointLoweringState::startNewStatepoint(SelectionDAGBuilder &Builder) {
   // Consistency check
   assert(PendingGCRelocateCalls.empty() &&
          "Trying to visit statepoint before finished processing previous one");
@@ -262,8 +261,7 @@ static SDNode *lowerCallFromStatepoint(ImmutableStatepoint StatepointSite,
       unsigned reg = Builder.FuncInfo.CreateRegs(Tmp->getType());
       Builder.CopyValueToVirtualRegister(Tmp, reg);
       Builder.FuncInfo.ValueMap[CS.getInstruction()] = reg;
-    }
-    else {
+    } else {
       // The value of the statepoint itself will be the value of call itself.
       // We'll replace the actually call node shortly.  gc_result will grab
       // this value.
@@ -290,7 +288,7 @@ static SDNode *lowerCallFromStatepoint(ImmutableStatepoint StatepointSite,
   // ch = eh_label ch (only in case of invoke statepoint)
   //
   // DAG root will be either last eh_label or callseq_end.
-    
+
   SDNode *CallNode = nullptr;
 
   // We just emitted a call, so it should be last thing generated
@@ -324,14 +322,12 @@ static SDNode *lowerCallFromStatepoint(ImmutableStatepoint StatepointSite,
 ///   Relocs - the gc_relocate corresponding to each base/ptr pair
 /// Elements of this arrays should be in one-to-one correspondence with each
 /// other i.e Bases[i], Ptrs[i] are from the same gcrelocate call
-static void
-getIncomingStatepointGCValues(SmallVectorImpl<const Value *> &Bases,
-                              SmallVectorImpl<const Value *> &Ptrs,
-                              SmallVectorImpl<const Value *> &Relocs,
-                              ImmutableStatepoint StatepointSite,
-                              SelectionDAGBuilder &Builder) {
+static void getIncomingStatepointGCValues(
+    SmallVectorImpl<const Value *> &Bases, SmallVectorImpl<const Value *> &Ptrs,
+    SmallVectorImpl<const Value *> &Relocs, ImmutableStatepoint StatepointSite,
+    SelectionDAGBuilder &Builder) {
   for (GCRelocateOperands relocateOpers :
-         StatepointSite.getRelocates(StatepointSite)) {
+       StatepointSite.getRelocates(StatepointSite)) {
     Relocs.push_back(relocateOpers.getUnderlyingCallSite().getInstruction());
     Bases.push_back(relocateOpers.basePtr());
     Ptrs.push_back(relocateOpers.derivedPtr());
@@ -400,7 +396,7 @@ static void lowerIncomingStatepointValue(SDValue Incoming,
     // This handles allocas as arguments to the statepoint (this is only
     // really meaningful for a deopt value.  For GC, we'd be trying to
     // relocate the address of the alloca itself?)
-    Ops.push_back(Builder.DAG.getTargetFrameIndex(FI->getIndex(), 
+    Ops.push_back(Builder.DAG.getTargetFrameIndex(FI->getIndex(),
                                                   Incoming.getValueType()));
   } else {
     // Otherwise, locate a spill slot and explicitly spill it so it
@@ -433,8 +429,8 @@ static void lowerStatepointMetaArgs(SmallVectorImpl<SDValue> &Ops,
   // be: deopt argument length, deopt arguments.., gc arguments...
 
   SmallVector<const Value *, 64> Bases, Ptrs, Relocations;
-  getIncomingStatepointGCValues(Bases, Ptrs, Relocations,
-                                StatepointSite, Builder);
+  getIncomingStatepointGCValues(Bases, Ptrs, Relocations, StatepointSite,
+                                Builder);
 
 #ifndef NDEBUG
   // Check that each of the gc pointer and bases we've gotten out of the
@@ -465,8 +461,6 @@ static void lowerStatepointMetaArgs(SmallVectorImpl<SDValue> &Ops,
   }
 #endif
 
-
-
   // Before we actually start lowering (and allocating spill slots for values),
   // reserve any stack slots which we judge to be profitable to reuse for a
   // particular value.  This is purely an optimization over the code below and
@@ -490,8 +484,7 @@ static void lowerStatepointMetaArgs(SmallVectorImpl<SDValue> &Ops,
   // lowered.  Note that this is the number of *Values* not the
   // number of SDValues required to lower them.
   const int NumVMSArgs = StatepointSite.numTotalVMSArgs();
-  Ops.push_back(
-      Builder.DAG.getTargetConstant(StackMaps::ConstantOp, MVT::i64));
+  Ops.push_back(Builder.DAG.getTargetConstant(StackMaps::ConstantOp, MVT::i64));
   Ops.push_back(Builder.DAG.getTargetConstant(NumVMSArgs, MVT::i64));
 
   assert(NumVMSArgs + 1 == std::distance(StatepointSite.vm_state_begin(),
@@ -523,18 +516,17 @@ static void lowerStatepointMetaArgs(SmallVectorImpl<SDValue> &Ops,
     lowerIncomingStatepointValue(Incoming, Ops, Builder);
   }
 
-  // If there are any explicit spill slots passed to the statepoint, record 
+  // If there are any explicit spill slots passed to the statepoint, record
   // them, but otherwise do not do anything special.  These are user provided
-  // allocas and give control over placement to the consumer.  In this case, 
+  // allocas and give control over placement to the consumer.  In this case,
   // it is the contents of the slot which may get updated, not the pointer to
   // the alloca
   for (Value *V : StatepointSite.gc_args()) {
     SDValue Incoming = Builder.getValue(V);
     if (FrameIndexSDNode *FI = dyn_cast<FrameIndexSDNode>(Incoming)) {
       // This handles allocas as arguments to the statepoint
-      Ops.push_back(Builder.DAG.getTargetFrameIndex(FI->getIndex(), 
+      Ops.push_back(Builder.DAG.getTargetFrameIndex(FI->getIndex(),
                                                     Incoming.getValueType()));
-
     }
   }
 }
@@ -547,9 +539,8 @@ void SelectionDAGBuilder::visitStatepoint(const CallInst &CI) {
   LowerStatepoint(ImmutableStatepoint(&CI));
 }
 
-void
-SelectionDAGBuilder::LowerStatepoint(ImmutableStatepoint ISP,
-                                     MachineBasicBlock *LandingPad/*=nullptr*/) {
+void SelectionDAGBuilder::LowerStatepoint(
+    ImmutableStatepoint ISP, MachineBasicBlock *LandingPad /*=nullptr*/) {
   // The basic scheme here is that information about both the original call and
   // the safepoint is encoded in the CallInst.  We create a temporary call and
   // lower it, then reverse engineer the calling sequence.
@@ -590,24 +581,56 @@ SelectionDAGBuilder::LowerStatepoint(ImmutableStatepoint ISP,
   // Get call node, we will replace it later with statepoint
   SDNode *CallNode = lowerCallFromStatepoint(ISP, LandingPad, *this);
 
-  // Construct the actual STATEPOINT node with all the appropriate arguments
-  // and return values.
+  // Construct the actual GC_TRANSITION_START, STATEPOINT, and GC_TRANSITION_END
+  // nodes with all the appropriate arguments and return values.
 
   // TODO: Currently, all of these operands are being marked as read/write in
   // PrologEpilougeInserter.cpp, we should special case the VMState arguments
   // and flags to be read-only.
   SmallVector<SDValue, 40> Ops;
 
-  // Calculate and push starting position of vmstate arguments
   // Call Node: Chain, Target, {Args}, RegMask, [Glue]
+  SDValue Chain = CallNode->getOperand(0);
+
   SDValue Glue;
-  if (CallNode->getGluedNode()) {
+  bool CallHasIncomingGlue = CallNode->getGluedNode();
+  if (CallHasIncomingGlue) {
     // Glue is always last operand
     Glue = CallNode->getOperand(CallNode->getNumOperands() - 1);
   }
+
+  // Build the GC_TRANSITION_START node if necessary.
+  if (ISP.isGCTransition()) {
+    SmallVector<SDValue, 8> Ops;
+
+    // Add chain
+    Ops.push_back(Chain);
+
+    // Add GC transition arguments
+    for (auto I = ISP.gc_transition_args_begin() + 1,
+              E = ISP.gc_transition_args_end();
+         I != E; ++I) {
+      Ops.push_back(getValue(*I));
+      Ops.push_back(DAG.getSrcValue(*I));
+    }
+
+    // Add glue if necessary
+    if (CallHasIncomingGlue)
+      Ops.push_back(Glue);
+
+    SDVTList NodeTys = DAG.getVTList(MVT::Other, MVT::Glue);
+
+    SDValue GCTransitionStart =
+        DAG.getNode(ISD::GC_TRANSITION_START, getCurSDLoc(), NodeTys, Ops);
+
+    Chain = GCTransitionStart.getValue(0);
+    Glue = GCTransitionStart.getValue(1);
+  }
+
+  // Calculate and push starting position of vmstate arguments
   // Get number of arguments incoming directly into call node
   unsigned NumCallRegArgs =
-      CallNode->getNumOperands() - (Glue.getNode() ? 4 : 3);
+      CallNode->getNumOperands() - (CallHasIncomingGlue ? 4 : 3);
   Ops.push_back(DAG.getTargetConstant(NumCallRegArgs, MVT::i32));
 
   // Add call target
@@ -617,7 +640,7 @@ SelectionDAGBuilder::LowerStatepoint(ImmutableStatepoint ISP,
   // Add call arguments
   // Get position of register mask in the call
   SDNode::op_iterator RegMaskIt;
-  if (Glue.getNode())
+  if (CallHasIncomingGlue)
     RegMaskIt = CallNode->op_end() - 2;
   else
     RegMaskIt = CallNode->op_end() - 1;
@@ -649,11 +672,39 @@ SelectionDAGBuilder::LowerStatepoint(ImmutableStatepoint ISP,
   // input.  This allows someone else to chain off us as needed.
   SDVTList NodeTys = DAG.getVTList(MVT::Other, MVT::Glue);
 
-  SDNode *StatepointMCNode = DAG.getMachineNode(TargetOpcode::STATEPOINT,
-                                                getCurSDLoc(), NodeTys, Ops);
+  SDNode *StatepointMCNode =
+      DAG.getMachineNode(TargetOpcode::STATEPOINT, getCurSDLoc(), NodeTys, Ops);
+
+  SDNode *SinkNode = StatepointMCNode;
+
+  // Build the GC_TRANSITION_END node if necessary.
+  if (ISP.isGCTransition()) {
+    SmallVector<SDValue, 8> Ops;
+
+    // Add chain
+    Ops.push_back(SDValue(StatepointMCNode, 0));
+
+    // Add GC transition arguments
+    for (auto I = ISP.gc_transition_args_begin() + 1,
+              E = ISP.gc_transition_args_end();
+         I != E; ++I) {
+      Ops.push_back(getValue(*I));
+      Ops.push_back(DAG.getSrcValue(*I));
+    }
+
+    // Add glue
+    Ops.push_back(SDValue(StatepointMCNode, 1));
+
+    SDVTList NodeTys = DAG.getVTList(MVT::Other, MVT::Glue);
+
+    SDValue GCTransitionStart =
+        DAG.getNode(ISD::GC_TRANSITION_START, getCurSDLoc(), NodeTys, Ops);
+
+    SinkNode = GCTransitionStart.getNode();
+  }
 
   // Replace original call
-  DAG.ReplaceAllUsesWith(CallNode, StatepointMCNode); // This may update Root
+  DAG.ReplaceAllUsesWith(CallNode, SinkNode); // This may update Root
   // Remove originall call node
   DAG.DeleteNode(CallNode);
 
@@ -671,8 +722,7 @@ void SelectionDAGBuilder::visitGCResult(const CallInst &CI) {
   // The result value of the gc_result is simply the result of the actual
   // call.  We've already emitted this, so just grab the value.
   Instruction *I = cast<Instruction>(CI.getArgOperand(0));
-  assert(isStatepoint(I) &&
-         "first argument must be a statepoint token");
+  assert(isStatepoint(I) && "first argument must be a statepoint token");
 
   if (isa<InvokeInst>(I)) {
     // For invokes we should have stored call result in a virtual register.
@@ -680,16 +730,15 @@ void SelectionDAGBuilder::visitGCResult(const CallInst &CI) {
     // register because statepoint and actuall call return types can be
     // different, and getValue() will use CopyFromReg of the wrong type,
     // which is always i32 in our case.
-    PointerType *CalleeType = cast<PointerType>(
-                                ImmutableStatepoint(I).actualCallee()->getType());
-    Type *RetTy = cast<FunctionType>(
-                                CalleeType->getElementType())->getReturnType();
+    PointerType *CalleeType =
+        cast<PointerType>(ImmutableStatepoint(I).actualCallee()->getType());
+    Type *RetTy =
+        cast<FunctionType>(CalleeType->getElementType())->getReturnType();
     SDValue CopyFromReg = getCopyFromRegs(I, RetTy);
 
     assert(CopyFromReg.getNode());
     setValue(&CI, CopyFromReg);
-  }
-  else {
+  } else {
     setValue(&CI, getValue(I));
   }
 }
@@ -721,9 +770,9 @@ void SelectionDAGBuilder::visitGCRelocate(const CallInst &CI) {
     // it may allow more scheduling opprtunities
     SDValue Chain = getRoot();
 
-    Loc = DAG.getLoad(SpillSlot.getValueType(), getCurSDLoc(), Chain,
-                      SpillSlot, MachinePointerInfo::getFixedStack(FI), false,
-                      false, false, 0);
+    Loc = DAG.getLoad(SpillSlot.getValueType(), getCurSDLoc(), Chain, SpillSlot,
+                      MachinePointerInfo::getFixedStack(FI), false, false,
+                      false, 0);
 
     StatepointLowering.setRelocLocation(SD, Loc);
 

--- a/lib/IR/Statepoint.cpp
+++ b/lib/IR/Statepoint.cpp
@@ -25,8 +25,10 @@ bool llvm::isStatepoint(const ImmutableCallSite &CS) {
     return false;
   }
 
-  const Function *F = CS.getCalledFunction();
-  return (F && F->getIntrinsicID() == Intrinsic::experimental_gc_statepoint);
+  if (const Function *F = CS.getCalledFunction())
+    return (F->getIntrinsicID() == Intrinsic::experimental_gc_statepoint ||
+            F->getIntrinsicID() == Intrinsic::experimental_gc_transition);
+  return false;
 }
 bool llvm::isStatepoint(const Value *inst) {
   if (isa<InvokeInst>(inst) || isa<CallInst>(inst)) {

--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -1488,8 +1488,10 @@ bool Verifier::VerifyAttributeCount(AttributeSet Attrs, unsigned Params) {
 /// \brief Verify that statepoint intrinsic is well formed.
 void Verifier::VerifyStatepoint(ImmutableCallSite CS) {
   assert(CS.getCalledFunction() &&
-         CS.getCalledFunction()->getIntrinsicID() ==
-           Intrinsic::experimental_gc_statepoint);
+         (CS.getCalledFunction()->getIntrinsicID() ==
+           Intrinsic::experimental_gc_statepoint ||
+          CS.getCalledFunction()->getIntrinsicID() ==
+           Intrinsic::experimental_gc_transition));
 
   const Instruction &CI = *CS.getInstruction();
 
@@ -2320,7 +2322,8 @@ void Verifier::visitInvokeInst(InvokeInst &II) {
     // TODO: Ideally we should use visitIntrinsicFunction here. But it uses
     //       CallInst as an input parameter. It not woth updating this whole
     //       function only to support statepoint verification.
-    if (F->getIntrinsicID() == Intrinsic::experimental_gc_statepoint)
+    if (F->getIntrinsicID() == Intrinsic::experimental_gc_statepoint ||
+        F->getIntrinsicID() == Intrinsic::experimental_gc_transition)
       VerifyStatepoint(ImmutableCallSite(&II));
 
   visitTerminatorInst(II);
@@ -2817,7 +2820,8 @@ void Verifier::visitInstruction(Instruction &I) {
               F->getIntrinsicID() == Intrinsic::donothing ||
               F->getIntrinsicID() == Intrinsic::experimental_patchpoint_void ||
               F->getIntrinsicID() == Intrinsic::experimental_patchpoint_i64 ||
-              F->getIntrinsicID() == Intrinsic::experimental_gc_statepoint,
+              F->getIntrinsicID() == Intrinsic::experimental_gc_statepoint ||
+              F->getIntrinsicID() == Intrinsic::experimental_gc_transition,
           "Cannot invoke an intrinsinc other than"
           " donothing or patchpoint",
           &I);
@@ -3234,6 +3238,7 @@ void Verifier::visitIntrinsicFunctionCall(Intrinsic::ID ID, CallInst &CI) {
   }
 
   case Intrinsic::experimental_gc_statepoint:
+  case Intrinsic::experimental_gc_transition:
     Assert(!CI.isInlineAsm(),
            "gc.statepoint support for inline assembly unimplemented", &CI);
     Assert(CI.getParent()->getParent()->hasGC(),
@@ -3252,8 +3257,10 @@ void Verifier::visitIntrinsicFunctionCall(Intrinsic::ID ID, CallInst &CI) {
     const Function *StatepointFn =
       StatepointCS.getInstruction() ? StatepointCS.getCalledFunction() : nullptr;
     Assert(StatepointFn && StatepointFn->isDeclaration() &&
-               StatepointFn->getIntrinsicID() ==
-                   Intrinsic::experimental_gc_statepoint,
+               (StatepointFn->getIntrinsicID() ==
+                   Intrinsic::experimental_gc_statepoint ||
+                StatepointFn->getIntrinsicID() ==
+                   Intrinsic::experimental_gc_transition),
            "gc.result operand #1 must be from a statepoint", &CI,
            CI.getArgOperand(0));
 

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -513,6 +513,10 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
 
   setOperationAction(ISD::DYNAMIC_STACKALLOC, getPointerTy(), Custom);
 
+  // GC_TRANSITION_START and GC_TRANSITION_END need custom lowering.
+  setOperationAction(ISD::GC_TRANSITION_START, MVT::Other, Custom);
+  setOperationAction(ISD::GC_TRANSITION_END, MVT::Other, Custom);
+
   if (!TM.Options.UseSoftFloat && X86ScalarSSEf64) {
     // f32 and f64 use SSE.
     // Set up the FP register classes.
@@ -17175,6 +17179,38 @@ static SDValue LowerFSINCOS(SDValue Op, const X86Subtarget *Subtarget,
   return DAG.getNode(ISD::MERGE_VALUES, dl, Tys, SinVal, CosVal);
 }
 
+SDValue X86TargetLowering::LowerGC_TRANSITION_START(SDValue Op,
+                                                    SelectionDAG &DAG) const {
+  // Replace with a NOOP for now.
+  SmallVector<SDValue, 2> Ops;
+
+  Ops.push_back(Op.getOperand(0));
+  if (Op->getGluedNode())
+	Ops.push_back(Op->getOperand(Op->getNumOperands() - 1));
+
+  SDLoc OpDL(Op);
+  SDVTList VTs = DAG.getVTList(MVT::Other, MVT::Glue);
+  SDValue NOOP(DAG.getMachineNode(X86::NOOP, SDLoc(Op), VTs, Ops), 0);
+
+  return NOOP;
+}
+
+SDValue X86TargetLowering::LowerGC_TRANSITION_END(SDValue Op,
+                                                  SelectionDAG &DAG) const {
+  // Replace with a NOOP for now.
+  SmallVector<SDValue, 2> Ops;
+
+  Ops.push_back(Op.getOperand(0));
+  if (Op->getGluedNode())
+	Ops.push_back(Op->getOperand(Op->getNumOperands() - 1));
+
+  SDLoc OpDL(Op);
+  SDVTList VTs = DAG.getVTList(MVT::Other, MVT::Glue);
+  SDValue NOOP(DAG.getMachineNode(X86::NOOP, SDLoc(Op), VTs, Ops), 0);
+
+  return NOOP;
+}
+
 /// LowerOperation - Provide custom lowering hooks for some operations.
 ///
 SDValue X86TargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
@@ -17262,6 +17298,9 @@ SDValue X86TargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
   case ISD::ADD:                return LowerADD(Op, DAG);
   case ISD::SUB:                return LowerSUB(Op, DAG);
   case ISD::FSINCOS:            return LowerFSINCOS(Op, Subtarget, DAG);
+  case ISD::GC_TRANSITION_START:
+                                return LowerGC_TRANSITION_START(Op, DAG);
+  case ISD::GC_TRANSITION_END:  return LowerGC_TRANSITION_END(Op, DAG);
   }
 }
 

--- a/lib/Target/X86/X86ISelLowering.h
+++ b/lib/Target/X86/X86ISelLowering.h
@@ -965,6 +965,8 @@ namespace llvm {
     SDValue LowerINIT_TRAMPOLINE(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerFLT_ROUNDS_(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerWin64_i128OP(SDValue Op, SelectionDAG &DAG) const;
+    SDValue LowerGC_TRANSITION_START(SDValue Op, SelectionDAG &DAG) const;
+    SDValue LowerGC_TRANSITION_END(SDValue Op, SelectionDAG &DAG) const;
 
     SDValue
       LowerFormalArguments(SDValue Chain,

--- a/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -374,6 +374,7 @@ static Value *findBaseDefiningValue(Value *I) {
       // fall through to general call handling
       break;
     case Intrinsic::experimental_gc_statepoint:
+    case Intrinsic::experimental_gc_transition:
     case Intrinsic::experimental_gc_result_float:
     case Intrinsic::experimental_gc_result_int:
       llvm_unreachable("these don't produce pointers");

--- a/test/CodeGen/X86/transition-call-lowering.ll
+++ b/test/CodeGen/X86/transition-call-lowering.ll
@@ -1,0 +1,104 @@
+; RUN: llc < %s | FileCheck %s
+; This file contains a collection of basic tests to ensure we didn't
+; screw up normal call lowering when there are no deopt or gc arguments.
+
+target datalayout = "e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare zeroext i1 @return_i1()
+declare zeroext i32 @return_i32()
+declare i32* @return_i32ptr()
+declare float @return_float()
+declare void @varargf(i32, ...)
+
+define i1 @test_i1_return() gc "statepoint-example" {
+; CHECK-LABEL: test_i1_return
+; This is just checking that a i1 gets lowered normally when there's no extra
+; state arguments to the statepoint
+; CHECK: pushq %rax
+; CHECK: callq return_i1
+; CHECK: popq %rdx
+; CHECK: retq
+entry:
+  %safepoint_token = tail call i32 (i1 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i1f(i1 ()* @return_i1, i32 0, i32 0, i32 0, i32 0)
+  %call1 = call zeroext i1 @llvm.experimental.gc.result.i1(i32 %safepoint_token)
+  ret i1 %call1
+}
+
+define i32 @test_i32_return() gc "statepoint-example" {
+; CHECK-LABEL: test_i32_return
+; CHECK: pushq %rax
+; CHECK: callq return_i32
+; CHECK: popq %rdx
+; CHECK: retq
+entry:
+  %safepoint_token = tail call i32 (i32 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i32f(i32 ()* @return_i32, i32 0, i32 0, i32 0, i32 0)
+  %call1 = call zeroext i32 @llvm.experimental.gc.result.i32(i32 %safepoint_token)
+  ret i32 %call1
+}
+
+define i32* @test_i32ptr_return() gc "statepoint-example" {
+; CHECK-LABEL: test_i32ptr_return
+; CHECK: pushq %rax
+; CHECK: callq return_i32ptr
+; CHECK: popq %rdx
+; CHECK: retq
+entry:
+  %safepoint_token = tail call i32 (i32* ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_p0i32f(i32* ()* @return_i32ptr, i32 0, i32 0, i32 0, i32 0)
+  %call1 = call i32* @llvm.experimental.gc.result.p0i32(i32 %safepoint_token)
+  ret i32* %call1
+}
+
+define float @test_float_return() gc "statepoint-example" {
+; CHECK-LABEL: test_float_return
+; CHECK: pushq %rax
+; CHECK: callq return_float
+; CHECK: popq %rax
+; CHECK: retq
+entry:
+  %safepoint_token = tail call i32 (float ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_f32f(float ()* @return_float, i32 0, i32 0, i32 0, i32 0)
+  %call1 = call float @llvm.experimental.gc.result.f32(i32 %safepoint_token)
+  ret float %call1
+}
+
+define i1 @test_relocate(i32 addrspace(1)* %a) gc "statepoint-example" {
+; CHECK-LABEL: test_relocate
+; Check that an ununsed relocate has no code-generation impact
+; CHECK: pushq %rax
+; CHECK: callq return_i1
+; CHECK-NEXT: .Ltmp9:
+; CHECK-NEXT: popq %rdx
+; CHECK-NEXT: retq
+entry:
+  %safepoint_token = tail call i32 (i1 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i1f(i1 ()* @return_i1, i32 0, i32 0, i32 0, i32 0, i32 addrspace(1)* %a)
+  %call1 = call i32 addrspace(1)* @llvm.experimental.gc.relocate.p1i32(i32 %safepoint_token, i32 5, i32 5)
+  %call2 = call zeroext i1 @llvm.experimental.gc.result.i1(i32 %safepoint_token)
+  ret i1 %call2
+}
+
+define void @test_void_vararg() gc "statepoint-example" {
+; CHECK-LABEL: test_void_vararg
+; Check a statepoint wrapping a *void* returning vararg function works
+; CHECK: callq varargf
+entry:
+  %safepoint_token = tail call i32 (void (i32, ...)*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidi32varargf(void (i32, ...)* @varargf, i32 2, i32 0, i32 42, i32 43, i32 0, i32 0)
+  ;; if we try to use the result from a statepoint wrapping a
+  ;; non-void-returning varargf, we will experience a crash.
+  ret void
+}
+
+declare i32 @llvm.experimental.gc.transition.p0f_i1f(i1 ()*, i32, i32, ...)
+declare i1 @llvm.experimental.gc.result.i1(i32)
+
+declare i32 @llvm.experimental.gc.transition.p0f_i32f(i32 ()*, i32, i32, ...)
+declare i32 @llvm.experimental.gc.result.i32(i32)
+
+declare i32 @llvm.experimental.gc.transition.p0f_p0i32f(i32* ()*, i32, i32, ...)
+declare i32* @llvm.experimental.gc.result.p0i32(i32)
+
+declare i32 @llvm.experimental.gc.transition.p0f_f32f(float ()*, i32, i32, ...)
+declare float @llvm.experimental.gc.result.f32(i32)
+
+declare i32 @llvm.experimental.gc.transition.p0f_isVoidi32varargf(void (i32, ...)*, i32, i32, ...)
+
+declare i32 addrspace(1)* @llvm.experimental.gc.relocate.p1i32(i32, i32, i32)

--- a/test/Transforms/RewriteStatepointsForGC/transition.ll
+++ b/test/Transforms/RewriteStatepointsForGC/transition.ll
@@ -1,0 +1,88 @@
+; This is a collection of really basic tests for gc.transition rewriting.
+; RUN:  opt %s -rewrite-statepoints-for-gc -S | FileCheck %s
+
+declare void @foo()
+
+; Trivial relocation over a single call
+define i8 addrspace(1)* @test1(i8 addrspace(1)* %obj) gc "statepoint-example" {
+; CHECK-LABEL: @test1
+; CHECK-LABEL: entry:
+; CHECK-NEXT: gc.transition
+; CHECK-NEXT: %obj.relocated = call coldcc i8 addrspace(1)*
+entry:
+  call i32 (void ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidf(void ()* @foo, i32 0, i32 0, i32 0, i32 5, i32 0, i32 -1, i32 0, i32 0, i32 0)
+  ret i8 addrspace(1)* %obj
+}
+
+; Two safepoints in a row (i.e. consistent liveness)
+define i8 addrspace(1)* @test2(i8 addrspace(1)* %obj) gc "statepoint-example" {
+; CHECK-LABEL: @test2
+; CHECK-LABEL: entry:
+; CHECK-NEXT: gc.transition
+; CHECK-NEXT: %obj.relocated = call coldcc i8 addrspace(1)*
+; CHECK-NEXT: gc.transition
+; CHECK-NEXT: %obj.relocated1 = call coldcc i8 addrspace(1)*
+entry:
+  call i32 (void ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidf(void ()* @foo, i32 0, i32 0, i32 0, i32 5, i32 0, i32 -1, i32 0, i32 0, i32 0)
+  call i32 (void ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidf(void ()* @foo, i32 0, i32 0, i32 0, i32 5, i32 0, i32 -1, i32 0, i32 0, i32 0)
+  ret i8 addrspace(1)* %obj
+}
+
+; A simple derived pointer
+define i8 @test3(i8 addrspace(1)* %obj) gc "statepoint-example" {
+; CHECK-LABEL: entry:
+; CHECK-NEXT: getelementptr
+; CHECK-NEXT: gc.transition
+; CHECK-NEXT: %derived.relocated = call coldcc i8 addrspace(1)*
+; CHECK-NEXT: %obj.relocated = call coldcc i8 addrspace(1)*
+; CHECK-NEXT: load i8, i8 addrspace(1)* %derived.relocated
+; CHECK-NEXT: load i8, i8 addrspace(1)* %obj.relocated
+entry:
+  %derived = getelementptr i8, i8 addrspace(1)* %obj, i64 10
+  call i32 (void ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidf(void ()* @foo, i32 0, i32 0, i32 0, i32 5, i32 0, i32 -1, i32 0, i32 0, i32 0)
+
+  %a = load i8, i8 addrspace(1)* %derived
+  %b = load i8, i8 addrspace(1)* %obj
+  %c = sub i8 %a, %b
+  ret i8 %c
+}
+
+; Tests to make sure we visit both the taken and untaken predeccessor 
+; of merge.  This was a bug in the dataflow liveness at one point.
+define i8 addrspace(1)* @test4(i1 %cmp, i8 addrspace(1)* %obj) gc "statepoint-example" {
+entry:
+  br i1 %cmp, label %taken, label %untaken
+
+taken:
+; CHECK-LABEL: taken:
+; CHECK-NEXT: gc.transition
+; CHECK-NEXT: %obj.relocated = call coldcc i8 addrspace(1)*
+  call i32 (void ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidf(void ()* @foo, i32 0, i32 0, i32 0, i32 5, i32 0, i32 -1, i32 0, i32 0, i32 0)
+  br label %merge
+
+untaken:
+; CHECK-LABEL: untaken:
+; CHECK-NEXT: gc.transition
+; CHECK-NEXT: %obj.relocated1 = call coldcc i8 addrspace(1)*
+  call i32 (void ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidf(void ()* @foo, i32 0, i32 0, i32 0, i32 5, i32 0, i32 -1, i32 0, i32 0, i32 0)
+  br label %merge
+
+merge:
+; CHECK-LABEL: merge:
+; CHECK-NEXT: %.0 = phi i8 addrspace(1)* [ %obj.relocated, %taken ], [ %obj.relocated1, %untaken ]
+; CHECK-NEXT: ret i8 addrspace(1)* %.0
+  ret i8 addrspace(1)* %obj
+}
+
+; When run over a function which doesn't opt in, should do nothing!
+define i8 addrspace(1)* @test5(i8 addrspace(1)* %obj) gc "ocaml" {
+; CHECK-LABEL: @test5
+; CHECK-LABEL: entry:
+; CHECK-NEXT: gc.transition
+; CHECK-NOT: %obj.relocated = call coldcc i8 addrspace(1)*
+entry:
+  call i32 (void ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidf(void ()* @foo, i32 0, i32 0, i32 0, i32 5, i32 0, i32 -1, i32 0, i32 0, i32 0)
+  ret i8 addrspace(1)* %obj
+}
+
+declare i32 @llvm.experimental.gc.transition.p0f_isVoidf(void ()*, i32, i32, ...)


### PR DESCRIPTION
This intrinsic may be used to support calls from functions that are
GC-aware ("managed functions") to functions that are not GC-aware
("unmanaged functions"). This intrinsic is similar to the existing
statepoint instruction, except that it offers the backend the
opportunity to insert (somewhat) arbitrary code to managed the
transition from managed code to unmanaged code and back.

In order to support the injection of transition code, this intrinsic
wraps the STATEPOINT DAG node generated by the usual statepoint
lowering with two additional nodes: GC_TRANSITION_START and
GC_TRANSITION_END. The intrinsic accepts an additional set of
parameters that are supplied as operands to these nodes that may
be used by the backend during code generation.