### PR TITLE
Lower GC_TRANSITION_{START,END} for CoreCLR on x86-64.

### DIFF
--- a/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
+++ b/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
@@ -611,7 +611,8 @@ void SelectionDAGBuilder::LowerStatepoint(
               E = ISP.gc_transition_args_end();
          I != E; ++I) {
       Ops.push_back(getValue(*I));
-      Ops.push_back(DAG.getSrcValue(*I));
+      if ((*I)->getType()->isPointerTy())
+        Ops.push_back(DAG.getSrcValue(*I));
     }
 
     // Add glue if necessary
@@ -689,7 +690,8 @@ void SelectionDAGBuilder::LowerStatepoint(
               E = ISP.gc_transition_args_end();
          I != E; ++I) {
       Ops.push_back(getValue(*I));
-      Ops.push_back(DAG.getSrcValue(*I));
+      if ((*I)->getType()->isPointerTy())
+        Ops.push_back(DAG.getSrcValue(*I));
     }
 
     // Add glue
@@ -698,7 +700,7 @@ void SelectionDAGBuilder::LowerStatepoint(
     SDVTList NodeTys = DAG.getVTList(MVT::Other, MVT::Glue);
 
     SDValue GCTransitionStart =
-        DAG.getNode(ISD::GC_TRANSITION_START, getCurSDLoc(), NodeTys, Ops);
+        DAG.getNode(ISD::GC_TRANSITION_END, getCurSDLoc(), NodeTys, Ops);
 
     SinkNode = GCTransitionStart.getNode();
   }

--- a/lib/Target/X86/X86CallingConv.td
+++ b/lib/Target/X86/X86CallingConv.td
@@ -739,11 +739,15 @@ def CSR_NoRegs : CalleeSavedRegs<(add)>;
 def CSR_32 : CalleeSavedRegs<(add ESI, EDI, EBX, EBP)>;
 def CSR_64 : CalleeSavedRegs<(add RBX, R12, R13, R14, R15, RBP)>;
 
+def CSR_32_NoGPRs : CalleeSavedRegs<(add EBP)>;
+def CSR_64_NoGPRs : CalleeSavedRegs<(add RBP)>;
+
 def CSR_32EHRet : CalleeSavedRegs<(add EAX, EDX, CSR_32)>;
 def CSR_64EHRet : CalleeSavedRegs<(add RAX, RDX, CSR_64)>;
 
 def CSR_Win64 : CalleeSavedRegs<(add RBX, RBP, RDI, RSI, R12, R13, R14, R15,
                                      (sequence "XMM%u", 6, 15))>;
+def CSR_Win64_NoGPRs : CalleeSavedRegs<(add RBP, (sequence "XMM%u", 6, 15))>;
 
 // All GPRs - except r11
 def CSR_64_RT_MostRegs : CalleeSavedRegs<(add CSR_64, RAX, RCX, RDX, RSI, RDI,

--- a/lib/Target/X86/X86ISelLowering.h
+++ b/lib/Target/X86/X86ISelLowering.h
@@ -965,8 +965,6 @@ namespace llvm {
     SDValue LowerINIT_TRAMPOLINE(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerFLT_ROUNDS_(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerWin64_i128OP(SDValue Op, SelectionDAG &DAG) const;
-    SDValue LowerGC_TRANSITION_START(SDValue Op, SelectionDAG &DAG) const;
-    SDValue LowerGC_TRANSITION_END(SDValue Op, SelectionDAG &DAG) const;
 
     SDValue
       LowerFormalArguments(SDValue Chain,
@@ -1006,6 +1004,12 @@ namespace llvm {
     lowerIdempotentRMWIntoFencedLoad(AtomicRMWInst *AI) const override;
 
     bool needsCmpXchgNb(const Type *MemType) const;
+
+    MachineBasicBlock *EmitGCTransitionRA(MachineInstr *MI,
+                                          MachineBasicBlock *MBB) const;
+
+    MachineBasicBlock *EmitGCTransitionPause(MachineInstr *MI,
+                                             MachineBasicBlock *MBB) const;
 
     /// Utility function to emit atomic-load-arith operations (and, or, xor,
     /// nand, max, min, umax, umin). It takes the corresponding instruction to

--- a/lib/Target/X86/X86InstrCompiler.td
+++ b/lib/Target/X86/X86InstrCompiler.td
@@ -56,19 +56,6 @@ def : Pat<(X86callseq_start timm:$amt1),
           (ADJCALLSTACKDOWN32 i32imm:$amt1, 0)>, Requires<[NotLP64]>;
 
 
-let usesCustomInserter = 1, Defs = [EFLAGS] in {
-def GC_TRANSITION_RA : I<0, Pseudo, (outs), (ins i8mem:$dst),
-                         "#GC_TRANSITION_RA",
-                         []>;
-}
-
-let usesCustomInserter = 1, Defs = [EFLAGS], Uses = [EFLAGS] in {
-def GC_TRANSITION_PAUSE : I<0, Pseudo, (outs), (ins i32imm:$fp, variable_ops),
-                            "#GC_TRANSITION_PAUSE",
-                            []>;
-}
-
-
 // ADJCALLSTACKDOWN/UP implicitly use/def RSP because they may be expanded into
 // a stack adjustment and the codegen must know that they may modify the stack
 // pointer before prolog-epilog rewriting occurs.
@@ -86,6 +73,35 @@ def ADJCALLSTACKUP64   : I<0, Pseudo, (outs), (ins i32imm:$amt1, i32imm:$amt2),
 }
 def : Pat<(X86callseq_start timm:$amt1),
           (ADJCALLSTACKDOWN64 i32imm:$amt1, 0)>, Requires<[IsLP64]>;
+
+
+// CoreCLR-specific GC transition prolog. This pseudo must precede a
+// STATEPOINT node, and lowers to code that looks like this:
+//
+//   lea $label, %vreg
+//   mov %vreg, %dst
+//   ...
+//   STATEPOINT
+// label:
+//   ...
+let usesCustomInserter = 1, Defs = [EFLAGS] in {
+def GC_TRANSITION_RA : I<0, Pseudo, (outs), (ins i8mem:$dst),
+                         "#GC_TRANSITION_RA",
+                         []>;
+}
+
+// CoreCLR-specific GC transition epilog. This expands to code that looks like
+// this:
+//
+//   je label
+//   call $pause
+// label:
+//   ...
+let usesCustomInserter = 1, Defs = [EFLAGS], Uses = [EFLAGS] in {
+def GC_TRANSITION_PAUSE : I<0, Pseudo, (outs), (ins i32imm:$fp, variable_ops),
+                            "#GC_TRANSITION_PAUSE",
+                            []>;
+}
 
 
 // x86-64 va_start lowering magic.

--- a/lib/Target/X86/X86InstrCompiler.td
+++ b/lib/Target/X86/X86InstrCompiler.td
@@ -56,6 +56,19 @@ def : Pat<(X86callseq_start timm:$amt1),
           (ADJCALLSTACKDOWN32 i32imm:$amt1, 0)>, Requires<[NotLP64]>;
 
 
+let usesCustomInserter = 1, Defs = [EFLAGS] in {
+def GC_TRANSITION_RA : I<0, Pseudo, (outs), (ins i8mem:$dst),
+                         "#GC_TRANSITION_RA",
+                         []>;
+}
+
+let usesCustomInserter = 1, Defs = [EFLAGS], Uses = [EFLAGS] in {
+def GC_TRANSITION_PAUSE : I<0, Pseudo, (outs), (ins i32imm:$fp, variable_ops),
+                            "#GC_TRANSITION_PAUSE",
+                            []>;
+}
+
+
 // ADJCALLSTACKDOWN/UP implicitly use/def RSP because they may be expanded into
 // a stack adjustment and the codegen must know that they may modify the stack
 // pointer before prolog-epilog rewriting occurs.

--- a/lib/Target/X86/X86MCInstLower.cpp
+++ b/lib/Target/X86/X86MCInstLower.cpp
@@ -414,6 +414,12 @@ void X86MCInstLower::Lower(const MachineInstr *MI, MCInst &OutMI) const {
       MCOp = MCOperand::CreateImm(MO.getImm());
       break;
     case MachineOperand::MO_MachineBasicBlock:
+      if (MO.getMBB()->hasAddressTaken())
+        MCOp = LowerSymbolOperand(MO, AsmPrinter.GetBlockAddressSymbol(
+                MO.getMBB()->getBasicBlock()));
+      else
+        MCOp = LowerSymbolOperand(MO, GetSymbolFromOperand(MO));
+      break;
     case MachineOperand::MO_GlobalAddress:
     case MachineOperand::MO_ExternalSymbol:
       MCOp = LowerSymbolOperand(MO, GetSymbolFromOperand(MO));

--- a/lib/Target/X86/X86RegisterInfo.cpp
+++ b/lib/Target/X86/X86RegisterInfo.cpp
@@ -336,6 +336,19 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
   return CSR_32_RegMask;
 }
 
+const uint32_t *
+X86RegisterInfo::getCallPreservedMaskWithoutGPRs(const uint32_t *Mask) const {
+  if (Mask == CSR_32_RegMask)
+    return CSR_32_NoGPRs_RegMask;
+  else if (Mask == CSR_64_RegMask)
+    return CSR_64_NoGPRs_RegMask;
+  else if (Mask == CSR_Win64_RegMask)
+    return CSR_Win64_NoGPRs_RegMask;
+
+  // Be intentionally conservative.
+  return CSR_NoRegs_RegMask;
+}
+
 const uint32_t*
 X86RegisterInfo::getNoPreservedMask() const {
   return CSR_NoRegs_RegMask;

--- a/lib/Target/X86/X86RegisterInfo.h
+++ b/lib/Target/X86/X86RegisterInfo.h
@@ -94,6 +94,7 @@ public:
   getCalleeSavedRegs(const MachineFunction* MF) const override;
   const uint32_t *getCallPreservedMask(const MachineFunction &MF,
                                        CallingConv::ID) const override;
+  const uint32_t *getCallPreservedMaskWithoutGPRs(const uint32_t *Mask) const;
   const uint32_t *getNoPreservedMask() const;
 
   /// getReservedRegs - Returns a bitset indexed by physical register number


### PR DESCRIPTION
Lowering is split between ISel and Emit. The pieces that do not need to
introduce new control flow are handled during the former phase; the rest
are handled during the latter. New pseudo-opcodes are added to the X86
target for those operations that must be deferred to Emit.