### PR TITLE
Support @llvm.read_register("ebp"|"rbp").

### DIFF
--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -15501,6 +15501,8 @@ unsigned X86TargetLowering::getRegisterByName(const char* RegName,
   unsigned Reg = StringSwitch<unsigned>(RegName)
                        .Case("esp", X86::ESP)
                        .Case("rsp", X86::RSP)
+                       .Case("ebp", X86::EBP)
+                       .Case("rbp", X86::RBP)
                        .Default(0);
   if (Reg)
     return Reg;


### PR DESCRIPTION
This is only valid in functions that use ebp or rbp as the frame pointer.