### PR TITLE
Expansion for the inline stack probe.

### DIFF
--- a/lib/Target/X86/X86FrameLowering.h
+++ b/lib/Target/X86/X86FrameLowering.h
@@ -32,9 +32,10 @@ public:
   /// Emit an inline sequence to probe the stack. This is required for all
   /// large stack allocations on Windows. The caller is required to materialize
   /// the number of bytes to probe in RAX/EAX.
-  static void emitStackProbeInline(MachineFunction &MF, MachineBasicBlock &MBB,
-                                   MachineBasicBlock::iterator MBBI, 
-                                   DebugLoc DL, bool IsProlog);
+  static MachineBasicBlock * emitStackProbeInline(MachineFunction &MF,
+                                                  MachineBasicBlock &MBB,
+                                                  MachineBasicBlock::iterator MBBI,
+                                                  DebugLoc DL, bool IsProlog);
 
   void emitCalleeSavedFrameMoves(MachineBasicBlock &MBB,
                                  MachineBasicBlock::iterator MBBI,

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -18936,17 +18936,17 @@ MachineBasicBlock *
 X86TargetLowering::EmitLoweredWinAlloca(MachineInstr *MI,
                                         MachineBasicBlock *BB) const {
   DebugLoc DL = MI->getDebugLoc();
-
+  MachineBasicBlock *ResumeBB = BB;
   assert(!Subtarget->isTargetMachO());
-
   if (Subtarget->isTargetWindowsCoreCLR()) {
-    X86FrameLowering::emitStackProbeInline(*BB->getParent(), *BB, MI, DL, false);
+    ResumeBB = X86FrameLowering::emitStackProbeInline(*BB->getParent(), *BB, MI,
+                                                      DL, false);
   } else {
     X86FrameLowering::emitStackProbeCall(*BB->getParent(), *BB, MI, DL);
   }
 
   MI->eraseFromParent();   // The pseudo instruction is gone now.
-  return BB;
+  return ResumeBB;
 }
 
 MachineBasicBlock *


### PR DESCRIPTION
This provides an inline expansion for the within-method locallocs for managed code. Prior to this we'd just adjust the stack pointer and hope for the best. Now we do the requisite page touches to ensure the stack grows the way the OS expects.

The inline instruction sequence is essentially the same as the __chkstk helper in the CRT save that virtual registers are used instead of R10 and R11.