### PR TITLE
Fix the GC pause calling convention.

### DIFF
--- a/lib/Target/X86/X86CallingConv.td
+++ b/lib/Target/X86/X86CallingConv.td
@@ -762,12 +762,15 @@ def CSR_64 : CalleeSavedRegs<(add RBX, R12, R13, R14, R15, RBP)>;
 def CSR_32_NoGPRs : CalleeSavedRegs<(add EBP)>;
 def CSR_64_NoGPRs : CalleeSavedRegs<(add RBP)>;
 
+def CSR_64_WithRet : CalleeSavedRegs<(add CSR_64, RAX, RDX, XMM0, XMM1, FP0, FP1)>;
+
 def CSR_32EHRet : CalleeSavedRegs<(add EAX, EDX, CSR_32)>;
 def CSR_64EHRet : CalleeSavedRegs<(add RAX, RDX, CSR_64)>;
 
 def CSR_Win64 : CalleeSavedRegs<(add RBX, RBP, RDI, RSI, R12, R13, R14, R15,
                                      (sequence "XMM%u", 6, 15))>;
 def CSR_Win64_NoGPRs : CalleeSavedRegs<(add RBP, (sequence "XMM%u", 6, 15))>;
+def CSR_Win64_WithRet : CalleeSavedRegs<(add CSR_Win64, RAX, XMM0)>;
 
 // All GPRs - except r11
 def CSR_64_RT_MostRegs : CalleeSavedRegs<(add CSR_64, RAX, RCX, RDX, RSI, RDI,

--- a/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -2947,8 +2947,11 @@ SDNode *X86DAGToDAGISel::Select(SDNode *Node) {
     SDVTList CMPVTs = CurDAG->getVTList(MVT::i32, MVT::Other, MVT::Glue);
 
     SDValue Comparand = CurDAG->getTargetConstant(0, MVT::i8);
-    const SDValue CMPOps[] = {Base, Scale, Index, Disp, Segment, Comparand, SDValue(StoreNode, 0), SDValue(StoreNode, 1)};
-    MachineSDNode *TrapCMPNode = CurDAG->getMachineNode(X86::CMP32mi8, SDLoc(Node), CMPVTs, CMPOps);
+    const SDValue CMPOps[] = {Base, Scale, Index, Disp, Segment, Comparand,
+                              SDValue(StoreNode, 0), SDValue(StoreNode, 1)};
+    MachineSDNode *TrapCMPNode = CurDAG->getMachineNode(X86::CMP32mi8,
+                                                        SDLoc(Node), CMPVTs,
+                                                        CMPOps);
     TrapCMPNode->setMemRefs(MemOp, MemOp + 1);
 
     CurDAG->DeleteNode(TrapLoadNode);

--- a/lib/Target/X86/X86RegisterInfo.cpp
+++ b/lib/Target/X86/X86RegisterInfo.cpp
@@ -349,6 +349,15 @@ X86RegisterInfo::getCallPreservedMaskWithoutGPRs(const uint32_t *Mask) const {
   return CSR_NoRegs_RegMask;
 }
 
+const uint32_t *
+X86RegisterInfo::getCallPreservedMaskWithReturns(const uint32_t *Mask) const {
+  if (Mask == CSR_64_RegMask)
+    return CSR_64_WithRet_RegMask;
+
+  assert(Mask == CSR_Win64_RegMask && "Unsupported calling convention");
+  return CSR_Win64_WithRet_RegMask;
+}
+
 const uint32_t*
 X86RegisterInfo::getNoPreservedMask() const {
   return CSR_NoRegs_RegMask;

--- a/lib/Target/X86/X86RegisterInfo.h
+++ b/lib/Target/X86/X86RegisterInfo.h
@@ -95,6 +95,7 @@ public:
   const uint32_t *getCallPreservedMask(const MachineFunction &MF,
                                        CallingConv::ID) const override;
   const uint32_t *getCallPreservedMaskWithoutGPRs(const uint32_t *Mask) const;
+  const uint32_t *getCallPreservedMaskWithReturns(const uint32_t *Mask) const;
   const uint32_t *getNoPreservedMask() const;
 
   /// getReservedRegs - Returns a bitset indexed by physical register number


### PR DESCRIPTION
The GC pause helper uses the C calling convention, but also saves
registers that may contain return values. Add the appropriate
regmask to the call instruction to keep the register allocator from
using registers that might be clobbered by the call.