### PR TITLE
Fix two GC-related bugs.

### DIFF
--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -18329,13 +18329,10 @@ X86TargetLowering::EmitGCTransitionRA(MachineInstr *MI,
   const uint32_t *RegMask = X86RI->getCallPreservedMaskWithoutGPRs(RegMaskIt->getRegMask());
   *RegMaskIt = MachineOperand::CreateRegMask(RegMask);
 
-  // Call
-  ThisMBB->push_back(CallMI->removeFromParent());
   ThisMBB->addSuccessor(SinkMBB);
-
   MI->eraseFromParent();
 
-  return SinkMBB;
+  return ThisMBB;
 }
 
 MachineBasicBlock *

--- a/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -69,7 +69,7 @@ namespace {
 struct RewriteStatepointsForGC : public FunctionPass {
   static char ID; // Pass identification, replacement for typeid
 
-  RewriteStatepointsForGC() : FunctionPass(ID) {
+  RewriteStatepointsForGC() : FunctionPass(ID), MustTrackBasePointers(true) {
     initializeRewriteStatepointsForGCPass(*PassRegistry::getPassRegistry());
   }
   bool runOnFunction(Function &F) override;

--- a/test/CodeGen/X86/statepoint-frameescape.ll
+++ b/test/CodeGen/X86/statepoint-frameescape.ll
@@ -9,7 +9,7 @@ entry:
 ; CHECK-LABEL: entry
   %ptr = alloca i32
 ; CHECK-NOT: statepoint
-  call void (...)* @llvm.frameescape(i32* %ptr)
+  call void (...) @llvm.frameescape(i32* %ptr)
 ; CHECK: statepoint
   ret void
 }

--- a/test/CodeGen/X86/transition-call-lowering.ll
+++ b/test/CodeGen/X86/transition-call-lowering.ll
@@ -17,10 +17,10 @@ define i1 @test_i1_return() gc "statepoint-example" {
 ; state arguments to the statepoint
 ; CHECK: pushq %rax
 ; CHECK: callq return_i1
-; CHECK: popq %rdx
+; CHECK: addq $8, %rsp
 ; CHECK: retq
 entry:
-  %safepoint_token = tail call i32 (i1 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i1f(i1 ()* @return_i1, i32 0, i32 0, i32 0, i32 0)
+  %safepoint_token = tail call i32 (i1 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i1f(i1 ()* @return_i1, i32 0, i32 0, i32 4, i8* null, i8* null, i8* null, i8* null, i32 0)
   %call1 = call zeroext i1 @llvm.experimental.gc.result.i1(i32 %safepoint_token)
   ret i1 %call1
 }
@@ -29,10 +29,10 @@ define i32 @test_i32_return() gc "statepoint-example" {
 ; CHECK-LABEL: test_i32_return
 ; CHECK: pushq %rax
 ; CHECK: callq return_i32
-; CHECK: popq %rdx
+; CHECK: addq $8, %rsp
 ; CHECK: retq
 entry:
-  %safepoint_token = tail call i32 (i32 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i32f(i32 ()* @return_i32, i32 0, i32 0, i32 0, i32 0)
+  %safepoint_token = tail call i32 (i32 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i32f(i32 ()* @return_i32, i32 0, i32 0, i32 4, i8* null, i8* null, i8* null, i8* null, i32 0)
   %call1 = call zeroext i32 @llvm.experimental.gc.result.i32(i32 %safepoint_token)
   ret i32 %call1
 }
@@ -41,10 +41,10 @@ define i32* @test_i32ptr_return() gc "statepoint-example" {
 ; CHECK-LABEL: test_i32ptr_return
 ; CHECK: pushq %rax
 ; CHECK: callq return_i32ptr
-; CHECK: popq %rdx
+; CHECK: addq $8, %rsp
 ; CHECK: retq
 entry:
-  %safepoint_token = tail call i32 (i32* ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_p0i32f(i32* ()* @return_i32ptr, i32 0, i32 0, i32 0, i32 0)
+  %safepoint_token = tail call i32 (i32* ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_p0i32f(i32* ()* @return_i32ptr, i32 0, i32 0, i32 4, i8* null, i8* null, i8* null, i8* null, i32 0)
   %call1 = call i32* @llvm.experimental.gc.result.p0i32(i32 %safepoint_token)
   ret i32* %call1
 }
@@ -53,10 +53,10 @@ define float @test_float_return() gc "statepoint-example" {
 ; CHECK-LABEL: test_float_return
 ; CHECK: pushq %rax
 ; CHECK: callq return_float
-; CHECK: popq %rax
+; CHECK: addq $8, %rsp
 ; CHECK: retq
 entry:
-  %safepoint_token = tail call i32 (float ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_f32f(float ()* @return_float, i32 0, i32 0, i32 0, i32 0)
+  %safepoint_token = tail call i32 (float ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_f32f(float ()* @return_float, i32 0, i32 0, i32 4, i8* null, i8* null, i8* null, i8* null, i32 0)
   %call1 = call float @llvm.experimental.gc.result.f32(i32 %safepoint_token)
   ret float %call1
 }
@@ -66,12 +66,12 @@ define i1 @test_relocate(i32 addrspace(1)* %a) gc "statepoint-example" {
 ; Check that an ununsed relocate has no code-generation impact
 ; CHECK: pushq %rax
 ; CHECK: callq return_i1
-; CHECK-NEXT: .Ltmp9:
-; CHECK-NEXT: popq %rdx
-; CHECK-NEXT: retq
+; CHECK: .LBB4_3:
+; CHECK: addq $8, %rsp
+; CHECK: retq
 entry:
-  %safepoint_token = tail call i32 (i1 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i1f(i1 ()* @return_i1, i32 0, i32 0, i32 0, i32 0, i32 addrspace(1)* %a)
-  %call1 = call i32 addrspace(1)* @llvm.experimental.gc.relocate.p1i32(i32 %safepoint_token, i32 5, i32 5)
+  %safepoint_token = tail call i32 (i1 ()*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_i1f(i1 ()* @return_i1, i32 0, i32 0, i32 4, i8* null, i8* null, i8* null, i8* null, i32 0, i32 addrspace(1)* %a)
+  %call1 = call i32 addrspace(1)* @llvm.experimental.gc.relocate.p1i32(i32 %safepoint_token, i32 9, i32 9)
   %call2 = call zeroext i1 @llvm.experimental.gc.result.i1(i32 %safepoint_token)
   ret i1 %call2
 }
@@ -81,7 +81,7 @@ define void @test_void_vararg() gc "statepoint-example" {
 ; Check a statepoint wrapping a *void* returning vararg function works
 ; CHECK: callq varargf
 entry:
-  %safepoint_token = tail call i32 (void (i32, ...)*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidi32varargf(void (i32, ...)* @varargf, i32 2, i32 0, i32 42, i32 43, i32 0, i32 0)
+  %safepoint_token = tail call i32 (void (i32, ...)*, i32, i32, ...) @llvm.experimental.gc.transition.p0f_isVoidi32varargf(void (i32, ...)* @varargf, i32 2, i32 0, i32 42, i32 43, i32 4, i8* null, i8* null, i8* null, i8* null, i32 0)
   ;; if we try to use the result from a statepoint wrapping a
   ;; non-void-returning varargf, we will experience a crash.
   ret void


### PR DESCRIPTION
The LLVM tests found two bugs in GC-related code:
- The flag that directs the statepoint rewriter not to track base pointers
  was not being properly initialized
- STATEPOINT nodes preceeded by GC_TRANSITION_RA nodes were not being
  properly rewritten

The test run is clean with these fixes.