### PR TITLE
Support CoreCLR filters

### DIFF
--- a/include/llvm/CodeGen/MachineModuleInfo.h
+++ b/include/llvm/CodeGen/MachineModuleInfo.h
@@ -72,17 +72,25 @@ struct SEHHandler {
 // Tree node indicating handler nesting relationship
 // FIXME: stop leaking this memory
 struct HandlerTreeNode {
+  enum ClauseKind {
+    Catch,
+    Finally,
+    Filter,
+  };
   HandlerTreeNode *Parent;
   const Function *Handler;
-  uint32_t CatchType;
+  ClauseKind Kind;
+  union {
+    uint32_t CatchType;
+    const Function *FilterFunction;
+  };
 };
 
 // Information used per protected region in CoreCLR EH table generation
 struct ClrEHClause {
   MCSymbol *Begin;
   MCSymbol *End;
-  const Function *Handler;
-  uint32_t CatchType;
+  HandlerTreeNode *Node;
 };
 
 // Function-wide EH info for CoreCLR

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1169,8 +1169,13 @@ void AsmPrinter::SetupMachineFunction(MachineFunction &MF) {
   CurrentFnBegin = nullptr;
   CurExceptionSym = nullptr;
   bool NeedsLocalForSize = MAI->needsLocalForSize();
+  // TODO: reconcile this once the new EH representation lands.  Need to emit
+  // for funclets and filters.  Late outlining generates artificial landingpads
+  // in funclets, but early filter outlining does not, hence the check
+  // on MF and its WinEHParent.
   if (!MMI->getLandingPads().empty() || MMI->hasDebugInfo() ||
-      NeedsLocalForSize) {
+      NeedsLocalForSize ||
+      (MF.getFunction() != MMI->getWinEHParent(MF.getFunction()))) {
     CurrentFnBegin = createTempSymbol("func_begin");
     if (NeedsLocalForSize)
       CurrentFnSymForSize = CurrentFnBegin;

--- a/lib/CodeGen/MachineModuleInfo.cpp
+++ b/lib/CodeGen/MachineModuleInfo.cpp
@@ -490,6 +490,17 @@ const Function *MachineModuleInfo::getPersonality() const {
   for (const LandingPadInfo &LPI : LandingPads)
     if (LPI.Personality)
       return LPI.Personality;
+  if (Context.getObjectFileInfo()
+          ->getTargetTriple()
+          .isWindowsCoreCLREnvironment()) {
+    // Need to report the personality for outlined filters even though the
+    // filter won't have a landing pad inside it.
+    // TODO: Update this to whatever the new mechanism is for handler funclets
+    // when WindowsEH is changed over to the new representation.
+    for (const Function *F : Personalities) {
+      return F;
+    }
+  }
   return nullptr;
 }
 


### PR DESCRIPTION
Expand HandlerTreeNode to have a ClauseKind (now that there are three) and
a FilterFunction used in filter handlers.

Change ClrEHClause to pass along a HandlerTreeNode opaquely rather than
replicating its fields.

Ensure that outlined filter handlers are inserted in the function list
just after the filters they handle.

Check in a few places that are determining whether to emit EH-relevant
info whether a function has a Win EH parent, so that early-outlined
filters are included.