### PR TITLE
SecretParam calling convention changes

### DIFF
--- a/lib/Target/X86/X86CallingConv.h
+++ b/lib/Target/X86/X86CallingConv.h
@@ -43,15 +43,6 @@ inline bool CC_X86_AnyReg_Error(unsigned &, MVT &, MVT &,
   return false;
 }
 
-inline bool hasCLRSecretParameterAttribute(unsigned ValNo, CCState &State) {
-  // CLR_SecretParameter is only valid when computing register allocation
-  // for function prologs.
-  assert(State.getCallOrPrologue() != ParmContext::Call);
-
-  const Function *Func = State.getMachineFunction().getFunction();
-  return Func->getAttributes().hasAttribute(ValNo + 1, "CLR_SecretParameter");
-}
-
 } // End llvm namespace
 
 #endif

--- a/lib/Target/X86/X86CallingConv.td
+++ b/lib/Target/X86/X86CallingConv.td
@@ -453,8 +453,8 @@ def CC_X86_64_CLR_VirtualDispatchStub : CallingConv<[
 ]>;
 
 def CC_X86_64_CLR_SecretParameter : CallingConv<[
-  // The secret parameter is passed in R10
-  CCIf<"hasCLRSecretParameterAttribute(ValNo, State)", CCAssignToReg<[R10]>>,
+  // The first pointer-sized argument is passed in R10
+  CCIfType<[i64], CCAssignToReg<[R10]>>,
 
   // Mingw64 and native Win64 use Win64 CC
   CCIfSubtarget<"isTargetWin64()", CCDelegateTo<CC_X86_Win64_C>>,
@@ -739,8 +739,8 @@ def CC_X86_32_CLR_VirtualDispatchStub : CallingConv<[
 ]>;
 
 def CC_X86_32_CLR_SecretParameter : CallingConv<[
-  // The secret parameter is passed in EAX
-  CCIf<"hasCLRSecretParameterAttribute(ValNo, State)", CCAssignToReg<[EAX]>>,
+  // The first pointer-sized argument is passed in EAX
+  CCIfType<[i32], CCAssignToReg<[EAX]>>,
 
   // Otherwise, drop to normal X86-32 CC
   CCDelegateTo<CC_X86_32_C>


### PR DESCRIPTION
Modify CLR_SecretParameter calling convention
to make the secret parameter the first pointer-sized parameter
(still passed in R10) rather than a parameter passed with a
"CLR_SecretParameter" attribute.
