### PR TITLE
Rename two functions for conformance

### DIFF
--- a/include/llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h
+++ b/include/llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h
@@ -54,9 +54,9 @@ protected:
       return RTDyld->getSymbol(Name);
     }
 
-    bool NeedsFinalization() const { return (State == Raw); }
+    bool needsFinalization() const { return (State == Raw); }
 
-    virtual void Finalize() = 0;
+    virtual void finalize() = 0;
 
     void mapSectionAddress(const void *LocalAddress, TargetAddress TargetAddr) {
       assert((State != Finalized) &&
@@ -121,7 +121,7 @@ private:
       : LinkedObjectSet(*MemMgr, *Resolver), MemMgr(std::move(MemMgr)),
         Resolver(std::move(Resolver)) { }
 
-    void Finalize() override {
+    void finalize() override {
       State = Finalizing;
       RTDyld->resolveRelocations();
       RTDyld->registerEHFrames();
@@ -232,7 +232,7 @@ public:
       if (Sym.isExported() || !ExportedSymbolsOnly) {
         auto Addr = Sym.getAddress();
         auto Flags = Sym.getFlags();
-        if (!(*H)->NeedsFinalization()) {
+        if (!(*H)->needsFinalization()) {
           // If this instance has already been finalized then we can just return
           // the address.
           return JITSymbol(Addr, Flags);
@@ -243,8 +243,8 @@ public:
           // functor is called.
           auto GetAddress =
             [this, Addr, H]() {
-              if ((*H)->NeedsFinalization()) {
-                (*H)->Finalize();
+              if ((*H)->needsFinalization()) {
+                (*H)->finalize();
                 if (NotifyFinalized)
                   NotifyFinalized(H);
               }
@@ -267,7 +267,7 @@ public:
   ///        given handle.
   /// @param H Handle for object set to emit/finalize.
   void emitAndFinalize(ObjSetHandleT H) {
-    (*H)->Finalize();
+    (*H)->finalize();
     if (NotifyFinalized)
       NotifyFinalized(H);
   }


### PR DESCRIPTION
Rename two functions to adhere to LLVM convention.
This change is necessary for LLILC ccFomat to succeed.

I'll submit the patch to LLVM as well, but checking in here
because the change is (a) trivial to merge and (b) necessary
to keep the lab green.