### PR TITLE
Fix to remove Visual C++ warning C4319 from SmallBitVector.h

### DIFF
--- a/include/llvm/ADT/SmallBitVector.h
+++ b/include/llvm/ADT/SmallBitVector.h
@@ -562,7 +562,7 @@ private:
       uint32_t M = Mask[0];
       if (InvertMask) M = ~M;
       if (AddBits) setSmallBits(getSmallBits() | M);
-      else         setSmallBits(getSmallBits() & ~M);
+      else         setSmallBits(getSmallBits() & ~(uintptr_t)M);
     }
   }
 };


### PR DESCRIPTION
Closes #85.

File llvm/include/llvm/ADT/SmallBitVector.h has the following code:

```
  template<bool AddBits, bool InvertMask>
  void applyMask(const uint32_t *Mask, unsigned MaskWords) {
    if (NumBaseBits == 64 && MaskWords >= 2) {
      uint64_t M = Mask[0] | (uint64_t(Mask[1]) << 32);
      if (InvertMask) M = ~M;
      if (AddBits) setSmallBits(getSmallBits() | M);
      else         setSmallBits(getSmallBits() & ~M);
    } else {
      uint32_t M = Mask[0];
      if (InvertMask) M = ~M;
      if (AddBits) setSmallBits(getSmallBits() | M);
      else         setSmallBits(getSmallBits() & ~M);
    }
  }
```

When compiled for a 64 bit target the Microsoft C++ compiler emits
a warning:

```
.../SmallBitVector.h(565): warning C4319: '~': zero extending 'uint32_t' to 'uintptr_t' of greater size
```

The line referred to is the one containing the last occurrence of "~M" in the method.

The correct way of avoiding this method depends on the desired semantics of the
applyMask method. This applyMask method is in the SmallBitVector class which
is a specialization of the BitVectorClass. SmallBitVector is supposed to have the same
semantics as BitVectorClass but be more efficient for small bitvectors that will fit
within a pointer-sized word.

If compiling the above for a 32 bit target the warning is not given because then
uintptr_t and uint32_t are the same size.

If compiling for a 64 bit target the code giving the warning can only be executed
if the number of mask words given is 1, because in this case NumBaseBits will
be 64. Since the mask words are 32 bits, this is a case where the mask
words do not cover the bitvector.

So what is the correct semantics when the mask does not cover the bitvector?

One possible interpretation would be that the mask is zero-extended to
the length of the bitvector before being applied. However a reading of the
source code of BitVector shows that this is not the case. In the BitVector
implementation the applyMask operation only affects the part of the
BitVector that is covered by the mask. The remainder of the BitVector
is unaffected. [In current LLVM usage the mask in fact always does
cover the BitVector, except in the bitvector unit tests].

So the correct fix is to replace the offending line with

```
      else         setSmallBits(getSmallBits() & ~(uintptr_t )M);
```

This zero-extends M before the "~" operation occurs, so the
higher-order bits become 1s which then have no effect when "&"
is applied. So the mask does not affect the result where the
mask is not covering.

An alternate fix I had considered but that would not be correct would be
to change the declaration of the second M to

```
      uintptr_t M = (uintptr_t )Mask[0];
```

This would give the wrong answer if InvertMask is true, as then
bits not covered by the mask would be affected.