### PR TITLE
Add CLR EH table generation for new EH; remove it for landingpad EH

### DIFF
--- a/include/llvm/CodeGen/FunctionLoweringInfo.h
+++ b/include/llvm/CodeGen/FunctionLoweringInfo.h
@@ -237,8 +237,6 @@ public:
 private:
   void addSEHHandlersForLPads(ArrayRef<const LandingPadInst *> LPads);
 
-  void buildHandlerTree(ArrayRef<const LandingPadInst *> LPads);
-
   /// LiveOutRegInfo - Information about live out vregs.
   IndexedMap<LiveOutInfo, VirtReg2IndexFunctor> LiveOutRegInfo;
 };

--- a/include/llvm/CodeGen/MachineModuleInfo.h
+++ b/include/llvm/CodeGen/MachineModuleInfo.h
@@ -69,37 +69,6 @@ struct SEHHandler {
   const BlockAddress *RecoverBA;
 };
 
-// Tree node indicating handler nesting relationship
-// FIXME: stop leaking this memory
-struct HandlerTreeNode {
-  enum ClauseKind {
-    Catch,
-    Finally,
-    Filter,
-  };
-  HandlerTreeNode *Parent;
-  const Function *Handler;
-  ClauseKind Kind;
-  union {
-    uint32_t CatchType;
-    const Function *FilterFunction;
-  };
-};
-
-// Information used per protected region in CoreCLR EH table generation
-struct ClrEHClause {
-  MCSymbol *Begin;
-  MCSymbol *End;
-  HandlerTreeNode *Node;
-};
-
-// Function-wide EH info for CoreCLR
-struct ClrEHFuncInfo {
-  SmallPtrSet<const Function *, 4> Handlers;
-  DenseMap<const Function *, std::pair<MCSymbol *, MCSymbol *>> StartEndLabelMap;
-  std::vector<ClrEHClause> Clauses;
-};
-
 //===----------------------------------------------------------------------===//
 /// LandingPadInfo - This structure is used to retain landing pad info for
 /// the current function.
@@ -110,7 +79,6 @@ struct LandingPadInfo {
   SmallVector<MCSymbol *, 1> EndLabels;    // Labels after invoke.
   SmallVector<SEHHandler, 1> SEHHandlers;  // SEH handlers active at this lpad.
   MCSymbol *LandingPadLabel;               // Label at beginning of landing pad.
-  HandlerTreeNode *TreeNode;               // Place in handler nesting tree (for CLR).
   std::vector<int> TypeIds;               // List of type ids (filters negative).
   int WinEHState;                         // WinEH specific state number.
 
@@ -215,7 +183,6 @@ class MachineModuleInfo : public ImmutablePass {
   EHPersonality PersonalityTypeCache;
 
   DenseMap<const Function *, std::unique_ptr<WinEHFuncInfo>> FuncInfoMap;
-  DenseMap<const Function *, std::unique_ptr<ClrEHFuncInfo>> ClrEHFuncInfoMap;
 
 public:
   static char ID; // Pass identification, replacement for typeid
@@ -255,7 +222,6 @@ public:
 
   const Function *getWinEHParent(const Function *F) const;
   WinEHFuncInfo &getWinEHFuncInfo(const Function *F);
-  ClrEHFuncInfo &getClrEHFuncInfo(const Function *F);
   bool hasWinEHFuncInfo(const Function *F) const {
     return FuncInfoMap.count(getWinEHParent(F)) > 0;
   }
@@ -383,9 +349,6 @@ public:
 
   void addSEHCleanupHandler(MachineBasicBlock *LandingPad,
                             const Function *Cleanup);
-
-  void addHandlerTreeNode(MachineBasicBlock *LandingPad,
-                          HandlerTreeNode *TreeNode);
 
   /// getTypeIDFor - Return the type id for the specified typeinfo.  This is
   /// function wide.

--- a/include/llvm/CodeGen/WinEHFuncInfo.h
+++ b/include/llvm/CodeGen/WinEHFuncInfo.h
@@ -159,12 +159,22 @@ struct WinEHTryBlockMapEntry {
   SmallVector<WinEHHandlerType, 1> HandlerArray;
 };
 
+enum class ClrHandlerType { Catch, Finally, Fault, Filter };
+
+struct ClrEHUnwindMapEntry {
+  MBBOrBasicBlock Handler;
+  uint32_t TypeToken;
+  int Parent;
+  ClrHandlerType HandlerType;
+};
+
 struct WinEHFuncInfo {
   DenseMap<const Instruction *, int> EHPadStateMap;
   DenseMap<MCSymbol *, std::pair<int, MCSymbol *>> InvokeToStateMap;
   SmallVector<WinEHUnwindMapEntry, 4> UnwindMap;
   SmallVector<WinEHTryBlockMapEntry, 4> TryBlockMap;
   SmallVector<SEHUnwindMapEntry, 4> SEHUnwindMap;
+  SmallVector<ClrEHUnwindMapEntry, 4> ClrEHUnwindMap;
   int UnwindHelpFrameIdx = INT_MAX;
   int UnwindHelpFrameOffset = -1;
 
@@ -191,5 +201,7 @@ void calculateWinCXXEHStateNumbers(const Function *ParentFn,
 
 void calculateSEHStateNumbers(const Function *ParentFn,
                               WinEHFuncInfo &FuncInfo);
+
+void calculateClrEHStateNumbers(const Function *Fn, WinEHFuncInfo &FuncInfo);
 }
 #endif // LLVM_CODEGEN_WINEHFUNCINFO_H

--- a/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -81,7 +81,7 @@ void WinException::beginFunction(const MachineFunction *MF) {
     F->needsUnwindTableEntry();
 
   shouldEmitPersonality =
-    forceEmitPersonality || ((hasLandingPads || hasEHFunclets || F != ParentF) &&
+      forceEmitPersonality || ((hasLandingPads || hasEHFunclets) &&
                                PerEncoding != dwarf::DW_EH_PE_omit && Per);
 
   unsigned LSDAEncoding = TLOF.getLSDAEncoding();
@@ -776,34 +776,6 @@ void WinException::emitExceptHandlerTable(const MachineFunction *MF) {
       CurState++;
     }
   }
-}
-
-static int getRank(HandlerTreeNode *Node) {
-  int Rank = 0;
-  while (Node != nullptr) {
-    ++Rank;
-    Node = Node->Parent;
-  }
-  return Rank;
-}
-static HandlerTreeNode *getAncestor(HandlerTreeNode *Left, HandlerTreeNode *Right) {
-  int LeftRank = getRank(Left);
-  int RightRank = getRank(Right);
-
-  while (LeftRank < RightRank) {
-    Right = Right->Parent;
-  }
-
-  while (RightRank < LeftRank) {
-    Left = Left->Parent;
-  }
-
-  while (Left != Right) {
-    Left = Left->Parent;
-    Right = Right->Parent;
-  }
-
-  return Left;
 }
 
 static int getRank(WinEHFuncInfo &FuncInfo, int State) {

--- a/lib/CodeGen/AsmPrinter/WinException.h
+++ b/lib/CodeGen/AsmPrinter/WinException.h
@@ -65,6 +65,7 @@ class LLVM_LIBRARY_VISIBILITY WinException : public EHStreamer {
   const MCExpr *create32bitRef(const Value *V);
   const MCExpr *getLabelPlusOne(MCSymbol *Label);
   const MCExpr *getOffset(MCSymbol *OffsetOf, MCSymbol *OffsetFrom);
+  const MCExpr *getOffset(const MCExpr *OffsetOf, MCSymbol *OffsetFrom);
 
 public:
   //===--------------------------------------------------------------------===//

--- a/lib/CodeGen/MachineModuleInfo.cpp
+++ b/lib/CodeGen/MachineModuleInfo.cpp
@@ -375,12 +375,6 @@ void MachineModuleInfo::addSEHCleanupHandler(MachineBasicBlock *LandingPad,
   LP.SEHHandlers.push_back(Handler);
 }
 
-void MachineModuleInfo::addHandlerTreeNode(MachineBasicBlock *LandingPad,
-                                            HandlerTreeNode *TreeNode) {
-  LandingPadInfo &LP = getOrCreateLandingPadInfo(LandingPad);
-  LP.TreeNode = TreeNode;
-}
-
 /// TidyLandingPads - Remap landing pad labels and remove any deleted landing
 /// pads.
 void MachineModuleInfo::TidyLandingPads(DenseMap<MCSymbol*, uintptr_t> *LPMap) {
@@ -485,12 +479,5 @@ WinEHFuncInfo &MachineModuleInfo::getWinEHFuncInfo(const Function *F) {
   auto &Ptr = FuncInfoMap[getWinEHParent(F)];
   if (!Ptr)
     Ptr.reset(new WinEHFuncInfo);
-  return *Ptr;
-}
-
-ClrEHFuncInfo &MachineModuleInfo::getClrEHFuncInfo(const Function *F) {
-  auto &Ptr = ClrEHFuncInfoMap[getWinEHParent(F)];
-  if (!Ptr)
-    Ptr.reset(new ClrEHFuncInfo);
   return *Ptr;
 }

--- a/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
+++ b/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
@@ -338,8 +338,6 @@ void FunctionLoweringInfo::set(const Function &fn, MachineFunction &mf,
       MachineBasicBlock *LPadMBB = MBBMap[LP->getParent()];
       MMI.addWinEHState(LPadMBB, EHInfo.EHPadStateMap[LP]);
     }
-  } else if (Personality == EHPersonality::CoreCLR) {
-    buildHandlerTree(LPads);
   }
 }
 
@@ -378,76 +376,6 @@ void FunctionLoweringInfo::addSEHHandlersForLPads(
         MMI.addSEHCleanupHandler(LPadMBB, Fini);
       }
     }
-  }
-}
-
-void FunctionLoweringInfo::buildHandlerTree(ArrayRef<const LandingPadInst *> LPads) {
-  MachineModuleInfo &MMI = MF->getMMI();
-  ClrEHFuncInfo &Info = MMI.getClrEHFuncInfo(Fn);
-  DenseMap<const Function *, HandlerTreeNode *> PadNodeMap;
-
-  // Iterate over all landing pads with llvm.eh.actions calls.
-  for (const LandingPadInst *LP : LPads) {
-    const IntrinsicInst *ActionsCall =
-      dyn_cast<IntrinsicInst>(LP->getNextNode());
-    if (!ActionsCall ||
-        ActionsCall->getIntrinsicID() != Intrinsic::eh_actions)
-        continue;
-
-    // Parse the llvm.eh.actions call we found.
-    MachineBasicBlock *LPadMBB = MBBMap[LP->getParent()];
-    SmallVector<std::unique_ptr<ActionHandler>, 4> Actions;
-    parseEHActions(ActionsCall, Actions);
-
-    // Iterate EH actions from most to least precedence, which means
-    // iterating in reverse.
-    HandlerTreeNode *Parent = nullptr;
-    for (auto I = Actions.rbegin(), E = Actions.rend(); I != E; ++I) {
-      ActionHandler *Action = I->get();
-      const Function *Handler = cast<Function>(Action->getHandlerBlockOrFunc());
-      HandlerTreeNode *&Current = PadNodeMap[Handler];
-      Info.Handlers.insert(Handler);
-      if (Current == nullptr) {
-        Current = new HandlerTreeNode();
-        Current->Parent = Parent;
-        Current->Handler = Handler;
-        CatchHandler *TheCatchHandler = dyn_cast<CatchHandler>(Action);
-        if (TheCatchHandler == nullptr) {
-          assert(isa<CleanupHandler>(Action));
-          // This is a fault or finally.  TODO: figure out if these need to
-          // be reported differently.
-          Current->CatchType = 0;
-          Current->Kind = HandlerTreeNode::ClauseKind::Finally;
-        } else {
-          assert(isa<Operator>(TheCatchHandler->getSelector()) && "Expected IntToPtr(handlerToken)");
-          Operator *IntToPtr = cast<Operator>(TheCatchHandler->getSelector());
-          if (IntToPtr->getOpcode() == CastInst::BitCast) {
-            // This is a filter handler.
-            const Function *FilterFunction =
-                cast<Function>(IntToPtr->stripPointerCasts());
-            Current->FilterFunction = FilterFunction;
-            Current->Kind = HandlerTreeNode::ClauseKind::Filter;
-            Info.Handlers.insert(FilterFunction);
-          } else {
-            // This is a catch handler.
-            assert(IntToPtr->getOpcode() == CastInst::IntToPtr &&
-                   "Expected IntToPtr(handlerToken)");
-            Value *TokenValue = IntToPtr->getOperand(0);
-            assert(isa<Constant>(TokenValue) && "Need literal token value");
-            uint64_t extendedToken =
-                *(cast<Constant>(TokenValue)->getUniqueInteger().getRawData());
-            uint32_t token = (uint32_t)extendedToken;
-            Current->CatchType = token;
-            Current->Kind = HandlerTreeNode::ClauseKind::Catch;
-          }
-        }
-      } else {
-        assert(Current->Parent == Parent);
-      }
-      Parent = Current;
-    }
-
-    MMI.addHandlerTreeNode(LPadMBB, Parent);
   }
 }
 

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1195,8 +1195,10 @@ static void
 findUnwindDestinations(FunctionLoweringInfo &FuncInfo,
                        const BasicBlock *EHPadBB,
                        SmallVectorImpl<MachineBasicBlock *> &UnwindDests) {
-  bool IsMSVCCXX = classifyEHPersonality(FuncInfo.Fn->getPersonalityFn()) ==
-                   EHPersonality::MSVC_CXX;
+  EHPersonality Personality =
+    classifyEHPersonality(FuncInfo.Fn->getPersonalityFn());
+  bool IsMSVCCXX = Personality == EHPersonality::MSVC_CXX;
+  bool IsCoreCLR = Personality == EHPersonality::CoreCLR;
   while (EHPadBB) {
     const Instruction *Pad = EHPadBB->getFirstNonPHI();
     if (isa<LandingPadInst>(Pad)) {
@@ -1213,7 +1215,7 @@ findUnwindDestinations(FunctionLoweringInfo &FuncInfo,
       // Add the catchpad handler to the possible destinations.
       UnwindDests.push_back(FuncInfo.MBBMap[CPI->getNormalDest()]);
       // In MSVC C++, catchblocks are funclets and need prologues.
-      if (IsMSVCCXX)
+      if (IsMSVCCXX || IsCoreCLR)
         UnwindDests.back()->setIsEHFuncletEntry();
       EHPadBB = CPI->getUnwindDest();
     } else if (const auto *CEPI = dyn_cast<CatchEndPadInst>(Pad)) {

--- a/lib/CodeGen/WinEHPrepare.cpp
+++ b/lib/CodeGen/WinEHPrepare.cpp
@@ -2860,6 +2860,93 @@ void llvm::calculateWinCXXEHStateNumbers(const Function *Fn,
   }
 }
 
+static int addClrEHHandler(WinEHFuncInfo &FuncInfo, int ParentState,
+                           ClrHandlerType HandlerType, uint32_t TypeToken,
+                           const BasicBlock *Handler) {
+  ClrEHUnwindMapEntry Entry;
+  Entry.Parent = ParentState;
+  Entry.Handler = Handler;
+  Entry.HandlerType = HandlerType;
+  Entry.TypeToken = TypeToken;
+  FuncInfo.ClrEHUnwindMap.push_back(Entry);
+  return FuncInfo.ClrEHUnwindMap.size() - 1;
+}
+
+void llvm::calculateClrEHStateNumbers(const Function *Fn,
+                                      WinEHFuncInfo &FuncInfo) {
+  // Return if it's already been done.
+  if (!FuncInfo.EHPadStateMap.empty())
+    return;
+
+  SmallVector<std::pair<const Instruction *, int>, 8> Worklist;
+
+  // Each pad needs to be able to refer to its parent, so scan the function
+  // looking for top-level handlers and seed the worklist with them.
+  for (const BasicBlock &BB : *Fn) {
+    if (!BB.isEHPad())
+      continue;
+    if (BB.isLandingPad())
+      report_fatal_error("CoreCLR EH cannot use landingpads");
+    const Instruction *FirstNonPHI = BB.getFirstNonPHI();
+    if (!doesEHPadUnwindToCaller(FirstNonPHI))
+      continue;
+    // queue this with sentinel parent state -1 to mean unwind to caller.
+    Worklist.emplace_back(FirstNonPHI, -1);
+  }
+
+  while (!Worklist.empty()) {
+    const Instruction *Pad;
+    int ParentState;
+    std::tie(Pad, ParentState) = Worklist.pop_back_val();
+
+    int PredState;
+    if (const CleanupEndPadInst *EndPad = dyn_cast<CleanupEndPadInst>(Pad)) {
+      FuncInfo.EHPadStateMap[EndPad] = ParentState;
+      // Queue the cleanuppad, in case it doesn't have a cleanupret.
+      Worklist.emplace_back(EndPad->getCleanupPad(), ParentState);
+      // Preds of the endpad should get the parent state.
+      PredState = ParentState;
+    } else if (const CleanupPadInst *Cleanup = dyn_cast<CleanupPadInst>(Pad)) {
+      if (FuncInfo.EHPadStateMap[Pad] != 0) {
+        // We might redundantly push a cleanup on the worklist through multiple
+        // of its exits.  Just ignore this redundant entry.
+        continue;
+      }
+      // CoreCLR personality uses arity to distinguish faults from finallies.
+      const BasicBlock *PadBlock = Cleanup->getParent();
+      ClrHandlerType HandlerType =
+          (Cleanup->getNumOperands() ? ClrHandlerType::Fault
+                                     : ClrHandlerType::Finally);
+      int NewState =
+          addClrEHHandler(FuncInfo, ParentState, HandlerType, 0, PadBlock);
+      FuncInfo.EHPadStateMap[Cleanup] = NewState;
+      // Propagate the new state to all preds of the cleanup
+      PredState = NewState;
+    } else if (const CatchEndPadInst *EndPad = dyn_cast<CatchEndPadInst>(Pad)) {
+      FuncInfo.EHPadStateMap[EndPad] = ParentState;
+      // Preds of the endpad should get the parent state.
+      PredState = ParentState;
+    } else if (const CatchPadInst *Catch = dyn_cast<CatchPadInst>(Pad)) {
+      const BasicBlock *Handler = Catch->getNormalDest();
+      uint32_t TypeToken = static_cast<uint32_t>(
+          cast<ConstantInt>(Catch->getArgOperand(0))->getZExtValue());
+      int NewState = addClrEHHandler(FuncInfo, ParentState,
+                                     ClrHandlerType::Catch, TypeToken, Handler);
+      FuncInfo.EHPadStateMap[Catch] = NewState;
+      // Preds of the catch get its state
+      PredState = NewState;
+    } else {
+      llvm_unreachable("Unexpected EH pad");
+    }
+
+    // Queue all predecessors with the given state
+    for (const BasicBlock *Pred : predecessors(Pad->getParent())) {
+      if ((Pred = getEHPadFromPredecessor(Pred)))
+        Worklist.emplace_back(Pred->getFirstNonPHI(), PredState);
+    }
+  }
+}
+
 void WinEHPrepare::replaceTerminatePadWithCleanup(Function &F) {
   if (Personality != EHPersonality::MSVC_CXX)
     return;


### PR DESCRIPTION
This is a PR for a change to go into the EH branch.

I think the relevant bits are stable enough to upstream this to LLVM (assuming I can figure out how to write a lit test that verifies we generate tables as expected), but want to PR it into the EH branch first since this provides a more useful diff to review from the LLILC perspective.

I split it into one commit that adds the new functionality and a second that removes the old; the second is a straight revert of the relevant code to match master.

Note that consuming these tables in LLILC and passing them along to the CLR is still being implemented, though I've got far enough to vet that these tables are reasonable for basic cases.

Note also that EH table generation isn't the whole of EH lowering; funclet prolog sequences will need some adjustment, we may need to change where nops are inserted, etc.

The support here for filters is just a stub, since LLILC currently (in the EH branch) translates filters to catches in the reader.