### PR TITLE
Undo CoreCLR xdata runtime_function nulling

### DIFF
--- a/include/llvm/Analysis/LibCallSemantics.h
+++ b/include/llvm/Analysis/LibCallSemantics.h
@@ -36,7 +36,6 @@ class InvokeInst;
   /// that we understand.  If so, return a description of it; otherwise return
   /// Unknown.
   EHPersonality classifyEHPersonality(const Value *Pers);
-  EHPersonality classifyEHPersonality(StringRef PersName);
 
   /// \brief Returns true if this personality function catches asynchronous
   /// exceptions.

--- a/lib/Analysis/LibCallSemantics.cpp
+++ b/lib/Analysis/LibCallSemantics.cpp
@@ -25,11 +25,7 @@ EHPersonality llvm::classifyEHPersonality(const Value *Pers) {
       Pers ? dyn_cast<Function>(Pers->stripPointerCasts()) : nullptr;
   if (!F)
     return EHPersonality::Unknown;
-  return classifyEHPersonality(F->getName());
-}
-
-EHPersonality llvm::classifyEHPersonality(StringRef PersName) {
-  return StringSwitch<EHPersonality>(PersName)
+  return StringSwitch<EHPersonality>(F->getName())
     .Case("__gnat_eh_personality", EHPersonality::GNU_Ada)
     .Case("__gxx_personality_v0",  EHPersonality::GNU_CXX)
     .Case("__gcc_personality_v0",  EHPersonality::GNU_C)

--- a/lib/MC/MCWin64EH.cpp
+++ b/lib/MC/MCWin64EH.cpp
@@ -208,15 +208,9 @@ static void EmitUnwindInfo(MCStreamer &streamer, WinEH::FrameInfo *info) {
     EmitRuntimeFunction(streamer, info->ChainedParent);
   else if (flags &
            ((Win64EH::UNW_TerminateHandler|Win64EH::UNW_ExceptionHandler) << 3)) {
-    if (streamer.getContext().getObjectFileInfo()->getTargetTriple().isWindowsCoreCLREnvironment()) {
-      // CoreCLR runtime expects the personality slot in the unwind info to be null
-      assert(classifyEHPersonality(info->ExceptionHandler->getName()) == EHPersonality::CoreCLR);
-      streamer.EmitIntValue(0, 4);
-    } else {
-      streamer.EmitValue(MCSymbolRefExpr::create(info->ExceptionHandler,
-                         MCSymbolRefExpr::VK_COFF_IMGREL32,
-                         context), 4);
-    }
+    streamer.EmitValue(MCSymbolRefExpr::create(info->ExceptionHandler,
+                        MCSymbolRefExpr::VK_COFF_IMGREL32,
+                        context), 4);
   }
   else if (numCodes == 0) {
     // The minimum size of an UNWIND_INFO struct is 8 bytes. If we're not


### PR DESCRIPTION
Now that LLILC processes relocations itself, there's no need to continue
suppressing the one that gets generated in .xdata for the pointer to the
personality function.