### PR TITLE
Mark catchret targets address-taken

### DIFF
--- a/lib/Target/X86/X86FrameLowering.cpp
+++ b/lib/Target/X86/X86FrameLowering.cpp
@@ -1434,6 +1434,10 @@ void X86FrameLowering::emitEpilogue(MachineFunction &MF,
           .addReg(ReturnReg)
           .addMBB(RestoreMBB);
     }
+    RestoreMBB->setHasAddressTaken();
+    // This line is needed to set the hasAddressTaken flag on the BasicBlock
+    // object.
+    BlockAddress::get(const_cast<BasicBlock *>(RestoreMBB->getBasicBlock()));
   }
 
   if (MBBI != MBB.end())


### PR DESCRIPTION
This is a workaround to unblock LLILC until D13774 lands to fix the issue
upstream.  This change follows a pattern used in the Hexagon back-end and
in GC transition lowering in the MS branch.