### PR TITLE
Update address-taken MBB handling

### DIFF
--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2480,8 +2480,11 @@ void AsmPrinter::EmitBasicBlockStart(const MachineBasicBlock &MBB) const {
     if (isVerbose())
       OutStreamer->AddComment("Block address taken");
 
-    for (MCSymbol *Sym : MMI->getAddrLabelSymbolToEmit(BB))
-      OutStreamer->EmitLabel(Sym);
+    // MBBs can have their address taken as part of CodeGen without having
+    // their corresponding BB's address taken in IR
+    if (BB->hasAddressTaken())
+      for (MCSymbol *Sym : MMI->getAddrLabelSymbolToEmit(BB))
+        OutStreamer->EmitLabel(Sym);
   }
 
   // Print some verbose block comments.

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2496,8 +2496,9 @@ void AsmPrinter::EmitBasicBlockStart(const MachineBasicBlock &MBB) const {
   }
 
   // Print the main label for the block.
-  if (MBB.pred_empty() ||
-      (isBlockOnlyReachableByFallthrough(&MBB) && !MBB.isEHFuncletEntry())) {
+  if (!MBB.hasAddressTaken() &&
+      (MBB.pred_empty() ||
+       (isBlockOnlyReachableByFallthrough(&MBB) && !MBB.isEHFuncletEntry()))) {
     if (isVerbose()) {
       // NOTE: Want this comment at start of line, don't emit with AddComment.
       OutStreamer->emitRawComment(" BB#" + Twine(MBB.getNumber()) + ":", false);

--- a/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -273,12 +273,10 @@ const MCExpr *WinException::create32bitRef(const MCSymbol *Value) {
                                  Asm->OutContext);
 }
 
-const MCExpr *WinException::create32bitRef(const Value *V) {
-  if (!V)
+const MCExpr *WinException::create32bitRef(const GlobalValue *GV) {
+  if (!GV)
     return MCConstantExpr::create(0, Asm->OutContext);
-  if (const auto *GV = dyn_cast<GlobalValue>(V))
-    return create32bitRef(Asm->getSymbol(GV));
-  return create32bitRef(MMI->getAddrLabelSymbol(cast<BasicBlock>(V)));
+  return create32bitRef(Asm->getSymbol(GV));
 }
 
 const MCExpr *WinException::getLabelPlusOne(const MCSymbol *Label) {

--- a/lib/CodeGen/AsmPrinter/WinException.h
+++ b/lib/CodeGen/AsmPrinter/WinException.h
@@ -18,6 +18,7 @@
 
 namespace llvm {
 class Function;
+class GlobalValue;
 class MachineFunction;
 class MCExpr;
 class Value;
@@ -66,7 +67,7 @@ class LLVM_LIBRARY_VISIBILITY WinException : public EHStreamer {
                                      StringRef FLinkageName);
 
   const MCExpr *create32bitRef(const MCSymbol *Value);
-  const MCExpr *create32bitRef(const Value *V);
+  const MCExpr *create32bitRef(const GlobalValue *GV);
   const MCExpr *getLabelPlusOne(const MCSymbol *Label);
   const MCExpr *getOffset(const MCSymbol *OffsetOf, const MCSymbol *OffsetFrom);
   const MCExpr *getOffsetPlusOne(const MCSymbol *OffsetOf,

--- a/lib/Target/X86/X86FrameLowering.cpp
+++ b/lib/Target/X86/X86FrameLowering.cpp
@@ -1434,10 +1434,9 @@ void X86FrameLowering::emitEpilogue(MachineFunction &MF,
           .addReg(ReturnReg)
           .addMBB(RestoreMBB);
     }
+    // Record that we've taken the address of RestoreMBB and no longer just
+    // reference it in a terminator.
     RestoreMBB->setHasAddressTaken();
-    // This line is needed to set the hasAddressTaken flag on the BasicBlock
-    // object.
-    BlockAddress::get(const_cast<BasicBlock *>(RestoreMBB->getBasicBlock()));
   }
 
   if (MBBI != MBB.end())

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -21635,7 +21635,7 @@ X86TargetLowering::emitEHSjLjSetJmp(MachineInstr *MI,
   // For v = setjmp(buf), we generate
   //
   // thisMBB:
-  //  buf[LabelOffset] = restoreMBB
+  //  buf[LabelOffset] = restoreMBB <-- takes address of restoreMBB
   //  SjLjSetup restoreMBB
   //
   // mainMBB:
@@ -21655,6 +21655,7 @@ X86TargetLowering::emitEHSjLjSetJmp(MachineInstr *MI,
   MF->insert(I, mainMBB);
   MF->insert(I, sinkMBB);
   MF->push_back(restoreMBB);
+  restoreMBB->setHasAddressTaken();
 
   MachineInstrBuilder MIB;
 

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -20519,9 +20519,6 @@ X86TargetLowering::EmitGCTransitionRA(MachineInstr *MI,
   SinkMBB->transferSuccessorsAndUpdatePHIs(MBB);
 
   SinkMBB->setHasAddressTaken();
-  // This line is needed to set the hasAddressTaken flag on the BasicBlock
-  // object.
-  BlockAddress::get(const_cast<BasicBlock *>(SinkMBB->getBasicBlock()));
 
   // ThisMBB:
   unsigned PtrStoreOpc = 0;

--- a/lib/Target/X86/X86MCInstLower.cpp
+++ b/lib/Target/X86/X86MCInstLower.cpp
@@ -415,9 +415,6 @@ X86MCInstLower::LowerMachineOperand(const MachineInstr *MI,
   case MachineOperand::MO_Immediate:
     return MCOperand::createImm(MO.getImm());
   case MachineOperand::MO_MachineBasicBlock:
-    if (MO.getMBB()->hasAddressTaken())
-      return LowerSymbolOperand(MO, AsmPrinter.GetBlockAddressSymbol(
-	      MO.getMBB()->getBasicBlock()));
     return LowerSymbolOperand(MO, GetSymbolFromOperand(MO));
     break;
   case MachineOperand::MO_GlobalAddress:

--- a/test/CodeGen/X86/coreclr-pinvoke.ll
+++ b/test/CodeGen/X86/coreclr-pinvoke.ll
@@ -1,0 +1,97 @@
+; RUN: llc -mtriple=x86_64-pc-win32-coreclr -o - < %s | FileCheck %s
+
+; IR for pinvoke stub generated for
+;   [DllImport("foo.dll")]
+;   static extern void foo();
+
+@"CORINFO_HELP_THROWNULLREF::JitHelper" = external global i64
+@"CORINFO_HELP_INIT_PINVOKE_FRAME::JitHelper" = external global i64
+@CaptureThreadGlobal = external constant i64
+@"CORINFO_HELP_STOP_FOR_GC::JitHelper" = external constant i64
+
+; CHECK-LABEL: .seh_proc DomainBoundILStubClass.IL_STUB_PInvoke
+define cc18 void @DomainBoundILStubClass.IL_STUB_PInvoke(i64 %param0) #0 gc "coreclr" {
+entry:
+  %"$SecretParam" = alloca i64
+  %loc0 = alloca i32
+  %InlinedCallFrame = alloca [64 x i8]
+  %ThreadPointer = alloca [0 x i8]*
+  %0 = getelementptr inbounds [64 x i8], [64 x i8]* %InlinedCallFrame, i32 0, i32 8
+; CHECK: callq "CORINFO_HELP_INIT_PINVOKE_FRAME::JitHelper"
+  %1 = call [0 x i8]* bitcast (i64* @"CORINFO_HELP_INIT_PINVOKE_FRAME::JitHelper" to [0 x i8]* (i8*, i64)*)(i8* %0, i64 %param0)
+  store [0 x i8]* %1, [0 x i8]** %ThreadPointer
+  %2 = getelementptr inbounds [64 x i8], [64 x i8]* %InlinedCallFrame, i32 0, i32 40
+  %3 = bitcast i8* %2 to i64*
+  %4 = call i64 @llvm.read_register.i64(metadata !0)
+  store i64 %4, i64* %3
+  %5 = getelementptr inbounds [64 x i8], [64 x i8]* %InlinedCallFrame, i32 0, i32 56
+  %6 = bitcast i8* %5 to i64*
+  %7 = call i64 @llvm.read_register.i64(metadata !1)
+  store i64 %7, i64* %6
+  store i64 %param0, i64* %"$SecretParam"
+  br label %8
+
+; <label>:8                                       ; preds = %entry
+  store i32 0, i32* %loc0
+  %9 = add i64 %param0, 72
+  %10 = inttoptr i64 %9 to i64*
+  %NullCheck = icmp eq i64* %10, null
+  br i1 %NullCheck, label %ThrowNullRef, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load i64, i64* %10, align 8
+  %13 = inttoptr i64 %12 to i64*
+  %NullCheck1 = icmp eq i64* %13, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %13, align 8
+  %16 = inttoptr i64 %15 to void ()*
+  %17 = getelementptr inbounds [64 x i8], [64 x i8]* %InlinedCallFrame, i32 0, i32 24
+  %18 = bitcast i8* %17 to i64*
+  store i64 %param0, i64* %18
+  %19 = getelementptr inbounds [64 x i8], [64 x i8]* %InlinedCallFrame, i32 0, i32 8
+  %20 = load [0 x i8]*, [0 x i8]** %ThreadPointer
+  %21 = getelementptr inbounds [0 x i8], [0 x i8]* %20, i32 0, i32 16
+  %22 = bitcast i8* %21 to i8**
+  store i8* %19, i8** %22
+  %23 = getelementptr inbounds [64 x i8], [64 x i8]* %InlinedCallFrame, i32 0, i32 48
+  %24 = bitcast i8* %23 to i8**
+  %25 = getelementptr inbounds [0 x i8], [0 x i8]* %20, i32 0, i32 12
+  %26 = load i64, i64* @"CORINFO_HELP_STOP_FOR_GC::JitHelper"
+; Check for the helper and address after call being stored as arguments to the call.
+; CHECK: movq "CORINFO_HELP_STOP_FOR_GC::JitHelper"(%rip), [[Reg1:%[^ ]+]]
+; CHECK-NEXT: movq [[Reg1]]
+; CHECK-NEXT: leaq [[LabelAfterCall:\.[^ (]+]](%rip), [[Reg2:%[^ ]+]]
+; CHECK-NEXT: movq [[Reg2]]
+; CHECK: callq {{.+$}}
+; CHECK-NOT: {{^ }}
+; CHECK: [[LabelAfterCall]]:
+  %27 = call i32 (i64, i32, void ()*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidf(i64 0, i32 0, void ()* %16, i32 0, i32 1, i32 4, i8** %24, i8* %25, i32* bitcast (i64* @CaptureThreadGlobal to i32*), i64 %26, i32 0)
+  store i8* null, i8** %24
+  %28 = getelementptr inbounds [64 x i8], [64 x i8]* %InlinedCallFrame, i32 0, i32 16
+  %29 = bitcast i8* %28 to i8**
+  %30 = load i8*, i8** %29
+  store i8* %30, i8** %22
+  ret void
+
+ThrowNullRef:                                     ; preds = %8
+  call void bitcast (i64* @"CORINFO_HELP_THROWNULLREF::JitHelper" to void ()*)() #2
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %11
+  call void bitcast (i64* @"CORINFO_HELP_THROWNULLREF::JitHelper" to void ()*)() #2
+  unreachable
+}
+
+; Function Attrs: nounwind readonly
+declare i64 @llvm.read_register.i64(metadata) #1
+
+declare i32 @llvm.experimental.gc.statepoint.p0f_isVoidf(i64, i32, void ()*, i32, i32, ...)
+
+attributes #0 = { "no-frame-pointer-elim"="true" }
+attributes #1 = { nounwind readonly }
+attributes #2 = { noreturn }
+
+!0 = !{!"rsp"}
+!1 = !{!"rbp"}

--- a/test/CodeGen/X86/late-address-taken.ll
+++ b/test/CodeGen/X86/late-address-taken.ll
@@ -1,0 +1,68 @@
+; RUN: llc -mtriple=x86_64-pc-windows-msvc < %s | FileCheck %s
+
+; Repro cases from PR25168
+
+; test @catchret - catchret target is not address-taken until PEI
+; splits it into lea/mov followed by ret.  Make sure the MBB is
+; handled, both by tempting BranchFolding to merge it with %early_out
+; and delete it, and by checking that we emit a proper reference
+; to it in the LEA
+
+declare void @ProcessCLRException()
+declare void @f()
+
+define void @catchret(i1 %b) personality void ()* @ProcessCLRException {
+entry:
+  br i1 %b, label %body, label %early_out
+early_out:
+  ret void
+body:
+  invoke void @f()
+          to label %exit unwind label %catch.pad
+catch.pad:
+  %catch = catchpad [i32 33554467]
+          to label %catch.body unwind label %catch.end
+catch.body:
+  catchret %catch to label %exit
+catch.end:
+  catchendpad unwind to caller
+exit:
+  ret void
+}
+; CHECK-LABEL: catchret:  # @catchret
+; CHECK: [[Exit:^[^ :]+]]: # Block address taken
+; CHECK-NEXT:              # %exit
+; CHECK: # %catch.pad
+; CHECK: .seh_endprolog
+; CHECK: leaq [[Exit]](%rip), %rax
+; CHECK: retq # CATCHRET
+
+
+; test @setjmp - similar to @catchret, but the MBB in question
+; is the one generated when the setjmp's block is split
+
+@buf = internal global [5 x i8*] zeroinitializer
+declare i8* @llvm.frameaddress(i32) nounwind readnone
+declare i8* @llvm.stacksave() nounwind
+declare i32 @llvm.eh.sjlj.setjmp(i8*) nounwind
+declare void @llvm.eh.sjlj.longjmp(i8*) nounwind
+
+define void @setjmp(i1 %b) nounwind {
+entry:
+  br i1 %b, label %early_out, label %sj
+early_out:
+  ret void
+sj:
+  %fp = call i8* @llvm.frameaddress(i32 0)
+  store i8* %fp, i8** getelementptr inbounds ([5 x i8*], [5 x i8*]* @buf, i64 0, i64 0), align 16
+  %sp = call i8* @llvm.stacksave()
+  store i8* %sp, i8** getelementptr inbounds ([5 x i8*], [5 x i8*]* @buf, i64 0, i64 2), align 16
+  call i32 @llvm.eh.sjlj.setjmp(i8* bitcast ([5 x i8*]* @buf to i8*))
+  ret void
+}
+; CHECK-LABEL: setjmp: # @setjmp
+; CHECK: # %sj
+; CHECK: leaq [[Label:\..+]](%rip), %[[Reg:.+]]{{$}}
+; CHECK-NEXT: movq %[[Reg]], buf
+; CHECK: {{^}}[[Label]]:  # Block address taken
+; CHECK-NEXT:              # %sj

--- a/test/CodeGen/X86/win-catchpad-csrs.ll
+++ b/test/CodeGen/X86/win-catchpad-csrs.ll
@@ -113,7 +113,8 @@ catchendblock:                                    ; preds = %catch,
 ; X64: callq useints
 ; X64: movl $1, %ecx
 ; X64: callq f
-; X64: [[contbb:\.LBB0_[0-9]+]]: # %try.cont
+; X64: [[contbb:\.LBB0_[0-9]+]]: # Block address taken
+; X64-NEXT:                      # %try.cont
 ; X64: addq $40, %rsp
 ; X64: popq %rbp
 ; X64: retq
@@ -188,7 +189,8 @@ catchendblock:                                    ; preds = %catch,
 ; X64: callq useints
 ; X64: movl $1, %ecx
 ; X64: callq f
-; X64: [[contbb:\.LBB1_[0-9]+]]: # %try.cont
+; X64: [[contbb:\.LBB1_[0-9]+]]: # Block address taken
+; X64-NEXT:                      # %try.cont
 ; X64: addq $40, %rsp
 ; X64-NOT: popq
 ; X64: popq %rsi
@@ -249,7 +251,8 @@ catchendblock:                                    ; preds = %catch,
 ; X64: .seh_endprologue
 ; X64: movl $1, %ecx
 ; X64: callq f
-; X64: [[contbb:\.LBB2_[0-9]+]]: # %try.cont
+; X64: [[contbb:\.LBB2_[0-9]+]]: # Block address taken
+; X64-NEXT:                      # %try.cont
 ; X64: addq $48, %rsp
 ; X64-NOT: popq
 ; X64: popq %rbp

--- a/test/CodeGen/X86/win-catchpad-nested.ll
+++ b/test/CodeGen/X86/win-catchpad-nested.ll
@@ -31,8 +31,10 @@ exit:
 
 ; Check the catchret targets
 ; CHECK-LABEL: test1: # @test1
-; CHECK: [[Exit:^[^: ]+]]: # %exit
-; CHECK: [[OuterRet:^[^: ]+]]: # %outer.ret
+; CHECK: [[Exit:^[^: ]+]]: # Block address taken
+; CHECK-NEXT:              # %exit
+; CHECK: [[OuterRet:^[^: ]+]]: # Block address taken
+; CHECK-NEXT:                  # %outer.ret
 ; CHECK-NEXT: leaq [[Exit]](%rip), %rax
 ; CHECK:      retq   # CATCHRET
 ; CHECK: {{^[^: ]+}}: # %inner.pad

--- a/test/CodeGen/X86/win-catchpad.ll
+++ b/test/CodeGen/X86/win-catchpad.ll
@@ -74,13 +74,15 @@ catchendblock:                                    ; preds = %catch, %catch.2, %c
 ; X86: [[contbb:LBB0_[0-9]+]]: # %try.cont
 ; X86: retl
 
-; X86: [[restorebb1:LBB0_[0-9]+]]: # %invoke.cont.2
+; X86: [[restorebb1:LBB0_[0-9]+]]: # Block address taken
+; X86-NEXT:                        # %invoke.cont.2
 ; X86: movl -16(%ebp), %esp
 ; X86: addl $12, %ebp
 ; X86: jmp [[contbb]]
 
 ; FIXME: These should be de-duplicated.
-; X86: [[restorebb2:LBB0_[0-9]+]]: # %invoke.cont.3
+; X86: [[restorebb2:LBB0_[0-9]+]]: # Block address taken
+; X86-NEXT:                        # %invoke.cont.3
 ; X86: movl -16(%ebp), %esp
 ; X86: addl $12, %ebp
 ; X86: jmp [[contbb]]
@@ -140,7 +142,8 @@ catchendblock:                                    ; preds = %catch, %catch.2, %c
 ; X64-DAG: leaq -[[local_offs:[0-9]+]](%rbp), %rdx
 ; X64-DAG: movl $1, %ecx
 ; X64: callq f
-; X64: [[contbb:\.LBB0_[0-9]+]]: # %try.cont
+; X64: [[contbb:\.LBB0_[0-9]+]]: # Block address taken
+; X64-NEXT:                      # %try.cont
 ; X64: addq $48, %rsp
 ; X64: popq %rbp
 ; X64: retq
@@ -253,7 +256,8 @@ catchendblock:
 ; X86: [[contbb:LBB1_[0-9]+]]: # %try.cont
 ; X86: retl
 
-; X86: [[restorebb:LBB1_[0-9]+]]: # %catch.done
+; X86: [[restorebb:LBB1_[0-9]+]]: # Block address taken
+; X86-NEXT:                       # %catch.done
 ; X86: movl -16(%ebp), %esp
 ; X86: addl $12, %ebp
 ; X86: jmp [[contbb]]
@@ -294,7 +298,8 @@ catchendblock:
 ; X64: .Ltmp[[before_call:[0-9]+]]:
 ; X64: callq f
 ; X64: .Ltmp[[after_call:[0-9]+]]:
-; X64: [[contbb:\.LBB1_[0-9]+]]: # %try.cont
+; X64: [[contbb:\.LBB1_[0-9]+]]: # Block address taken
+; X64-NEXT:                      # %try.cont
 ; X64: addq $48, %rsp
 ; X64: popq %rbp
 ; X64: retq


### PR DESCRIPTION
This PR has two commits.  The first is just the change that's been approved to commit upstream in [D13774](http://reviews.llvm.org/D13774), rebased to the MS branch.  The second changes how address-taken-ness is handled in the lowering of GC transitions (which only exists in the MS branch).
The first commit is included because this seems like the best way to get that change to the MS branch; checking it in upstream and letting that flow down without the second change would break catchret lowering (because of some code in LowerMachineOperand that the MS branch has which does not exist upstream), and checking in the second change without the first would similarly break GC transition lowering.
The second commit is included to fix the issue with catchret lowering, and at the same time bring the GC transition lowering over to the same strategy that catchret lowering is using.  This requires a change to AsmPrinter::EmitBasicBlockStart to fix an issue with MBBs that are address-taken, and which are entered only by fall-through, and whose corresponding BBs are not address-taken.  Since ToT will never generate such a thing (address-taken MBBs with non-address-taken BBs only come from setjmp and catchret, each of which imply a non-fallthrough predecessor), I think it makes sense to apply this fix and add this test that illustrates the issue to the MS branch, to be upstreamed when the GC transition lowering which can expose the issue is upstreamed.