### PR TITLE
FI

### DIFF
--- a/docs/LangRef.rst
+++ b/docs/LangRef.rst
@@ -8386,7 +8386,7 @@ Syntax:
 
 ::
 
-      <result> = [tail | musttail] call [cconv] [ret attrs] <ty> [<fnty>*] <fnptrval>(<function args>) [fn attrs]
+      <result> = [tail | musttail | notail ] call [cconv] [ret attrs] <ty> [<fnty>*] <fnptrval>(<function args>) [fn attrs]
                    [ operand bundles ]
 
 Overview:
@@ -8438,6 +8438,10 @@ This instruction requires several arguments:
       ``llvm::GuaranteedTailCallOpt`` is ``true``.
    -  `Platform-specific constraints are
       met. <CodeGenerator.html#tailcallopt>`_
+
+#. The optional ``notail`` marker indicates that the optimizers should not add
+   ``tail`` or ``musttail`` markers to the call. It is used to prevent tail
+   call optimization from being performed on the call.
 
 #. The optional "cconv" marker indicates which :ref:`calling
    convention <callingconv>` the call should use. If none is

--- a/examples/BrainF/BrainFDriver.cpp
+++ b/examples/BrainF/BrainFDriver.cpp
@@ -64,9 +64,9 @@ void addMainFunction(Module *mod) {
                           IntegerType::getInt8Ty(mod->getContext()))), NULL));
   {
     Function::arg_iterator args = main_func->arg_begin();
-    Value *arg_0 = args++;
+    Value *arg_0 = &*args++;
     arg_0->setName("argc");
-    Value *arg_1 = args++;
+    Value *arg_1 = &*args++;
     arg_1->setName("argv");
   }
 

--- a/examples/Fibonacci/fibonacci.cpp
+++ b/examples/Fibonacci/fibonacci.cpp
@@ -52,7 +52,7 @@ static Function *CreateFibFunction(Module *M, LLVMContext &Context) {
   Value *Two = ConstantInt::get(Type::getInt32Ty(Context), 2);
 
   // Get pointer to the integer argument of the add1 function...
-  Argument *ArgX = FibF->arg_begin();   // Get the arg.
+  Argument *ArgX = &*FibF->arg_begin(); // Get the arg.
   ArgX->setName("AnArg");            // Give it a nice symbolic name for fun.
 
   // Create the true_block.

--- a/examples/HowToUseJIT/HowToUseJIT.cpp
+++ b/examples/HowToUseJIT/HowToUseJIT.cpp
@@ -80,7 +80,7 @@ int main() {
 
   // Get pointers to the integer argument of the add1 function...
   assert(Add1F->arg_begin() != Add1F->arg_end()); // Make sure there's an arg
-  Argument *ArgX = Add1F->arg_begin();  // Get the arg
+  Argument *ArgX = &*Add1F->arg_begin();          // Get the arg
   ArgX->setName("AnArg");            // Give it a nice symbolic name for fun.
 
   // Create the add instruction, inserting it into the end of BB.

--- a/examples/Kaleidoscope/Orc/fully_lazy/toy.cpp
+++ b/examples/Kaleidoscope/Orc/fully_lazy/toy.cpp
@@ -1085,7 +1085,7 @@ void PrototypeAST::CreateArgumentAllocas(Function *F, IRGenContext &C) {
     AllocaInst *Alloca = CreateEntryBlockAlloca(F, Args[Idx]);
 
     // Store the initial value into the alloca.
-    C.getBuilder().CreateStore(AI, Alloca);
+    C.getBuilder().CreateStore(&*AI, Alloca);
 
     // Add arguments to variable symbol table.
     C.NamedValues[Args[Idx]] = Alloca;

--- a/examples/Kaleidoscope/Orc/initial/toy.cpp
+++ b/examples/Kaleidoscope/Orc/initial/toy.cpp
@@ -1084,7 +1084,7 @@ void PrototypeAST::CreateArgumentAllocas(Function *F, IRGenContext &C) {
     AllocaInst *Alloca = CreateEntryBlockAlloca(F, Args[Idx]);
 
     // Store the initial value into the alloca.
-    C.getBuilder().CreateStore(AI, Alloca);
+    C.getBuilder().CreateStore(&*AI, Alloca);
 
     // Add arguments to variable symbol table.
     C.NamedValues[Args[Idx]] = Alloca;

--- a/examples/Kaleidoscope/Orc/lazy_codegen/toy.cpp
+++ b/examples/Kaleidoscope/Orc/lazy_codegen/toy.cpp
@@ -1084,7 +1084,7 @@ void PrototypeAST::CreateArgumentAllocas(Function *F, IRGenContext &C) {
     AllocaInst *Alloca = CreateEntryBlockAlloca(F, Args[Idx]);
 
     // Store the initial value into the alloca.
-    C.getBuilder().CreateStore(AI, Alloca);
+    C.getBuilder().CreateStore(&*AI, Alloca);
 
     // Add arguments to variable symbol table.
     C.NamedValues[Args[Idx]] = Alloca;

--- a/examples/Kaleidoscope/Orc/lazy_irgen/toy.cpp
+++ b/examples/Kaleidoscope/Orc/lazy_irgen/toy.cpp
@@ -1084,7 +1084,7 @@ void PrototypeAST::CreateArgumentAllocas(Function *F, IRGenContext &C) {
     AllocaInst *Alloca = CreateEntryBlockAlloca(F, Args[Idx]);
 
     // Store the initial value into the alloca.
-    C.getBuilder().CreateStore(AI, Alloca);
+    C.getBuilder().CreateStore(&*AI, Alloca);
 
     // Add arguments to variable symbol table.
     C.NamedValues[Args[Idx]] = Alloca;

--- a/examples/ParallelJIT/ParallelJIT.cpp
+++ b/examples/ParallelJIT/ParallelJIT.cpp
@@ -50,7 +50,7 @@ static Function* createAdd1(Module *M) {
 
   // Get pointers to the integer argument of the add1 function...
   assert(Add1F->arg_begin() != Add1F->arg_end()); // Make sure there's an arg
-  Argument *ArgX = Add1F->arg_begin();  // Get the arg
+  Argument *ArgX = &*Add1F->arg_begin();          // Get the arg
   ArgX->setName("AnArg");            // Give it a nice symbolic name for fun.
 
   // Create the add instruction, inserting it into the end of BB.
@@ -80,7 +80,7 @@ static Function *CreateFibFunction(Module *M) {
   Value *Two = ConstantInt::get(Type::getInt32Ty(M->getContext()), 2);
 
   // Get pointer to the integer argument of the add1 function...
-  Argument *ArgX = FibF->arg_begin();   // Get the arg.
+  Argument *ArgX = &*FibF->arg_begin(); // Get the arg.
   ArgX->setName("AnArg");            // Give it a nice symbolic name for fun.
 
   // Create the true_block.

--- a/include/llvm/ADT/ilist.h
+++ b/include/llvm/ADT/ilist.h
@@ -220,8 +220,8 @@ private:
   template<class T> void operator-(T) const;
 public:
 
-  ilist_iterator(pointer NP) : NodePtr(NP) {}
-  ilist_iterator(reference NR) : NodePtr(&NR) {}
+  explicit ilist_iterator(pointer NP) : NodePtr(NP) {}
+  explicit ilist_iterator(reference NR) : NodePtr(&NR) {}
   ilist_iterator() : NodePtr(nullptr) {}
 
   // This is templated so that we can allow constructing a const iterator from
@@ -241,7 +241,7 @@ public:
   void reset(pointer NP) { NodePtr = NP; }
 
   // Accessors...
-  operator pointer() const {
+  explicit operator pointer() const {
     return NodePtr;
   }
 

--- a/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/include/llvm/Bitcode/LLVMBitCodes.h
@@ -335,6 +335,15 @@ enum { BITCODE_CURRENT_EPOCH = 0 };
     SYNCHSCOPE_CROSSTHREAD = 1
   };
 
+  /// Markers and flags for call instruction.
+  enum CallMarkersFlags {
+    CALL_TAIL = 0,
+    CALL_CCONV = 1,
+    CALL_MUSTTAIL = 14,
+    CALL_EXPLICIT_TYPE = 15,
+    CALL_NOTAIL = 16
+  };
+
   // The function body block (FUNCTION_BLOCK_ID) describes function bodies.  It
   // can contain a constant block (CONSTANTS_BLOCK_ID).
   enum FunctionCodes {

--- a/include/llvm/IR/CallSite.h
+++ b/include/llvm/IR/CallSite.h
@@ -375,8 +375,8 @@ public:
     CALLSITE_DELEGATE_GETTER(getNumTotalBundleOperands());
   }
 
-  OperandBundleUse getOperandBundle(unsigned Index) const {
-    CALLSITE_DELEGATE_GETTER(getOperandBundle(Index));
+  OperandBundleUse getOperandBundleAt(unsigned Index) const {
+    CALLSITE_DELEGATE_GETTER(getOperandBundleAt(Index));
   }
 
   Optional<OperandBundleUse> getOperandBundle(StringRef Name) const {

--- a/include/llvm/IR/InstrTypes.h
+++ b/include/llvm/IR/InstrTypes.h
@@ -1232,7 +1232,7 @@ public:
   }
 
   /// \brief Return the operand bundle at a specific index.
-  OperandBundleUse getOperandBundle(unsigned Index) const {
+  OperandBundleUse getOperandBundleAt(unsigned Index) const {
     assert(Index < getNumOperandBundles() && "Index out of bounds!");
     return operandBundleFromBundleOpInfo(*(bundle_op_info_begin() + Index));
   }
@@ -1242,7 +1242,7 @@ public:
   unsigned countOperandBundlesOfType(StringRef Name) const {
     unsigned Count = 0;
     for (unsigned i = 0, e = getNumOperandBundles(); i != e; ++i)
-      if (getOperandBundle(i).Tag == Name)
+      if (getOperandBundleAt(i).Tag == Name)
         Count++;
 
     return Count;
@@ -1256,7 +1256,7 @@ public:
     assert(countOperandBundlesOfType(Name) < 2 && "Precondition violated!");
 
     for (unsigned i = 0, e = getNumOperandBundles(); i != e; ++i) {
-      OperandBundleUse U = getOperandBundle(i);
+      OperandBundleUse U = getOperandBundleAt(i);
       if (U.Tag == Name)
         return U;
     }

--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -1489,15 +1489,20 @@ public:
   }
 
   // Note that 'musttail' implies 'tail'.
-  enum TailCallKind { TCK_None = 0, TCK_Tail = 1, TCK_MustTail = 2 };
+  enum TailCallKind { TCK_None = 0, TCK_Tail = 1, TCK_MustTail = 2,
+                      TCK_NoTail = 3 };
   TailCallKind getTailCallKind() const {
     return TailCallKind(getSubclassDataFromInstruction() & 3);
   }
   bool isTailCall() const {
-    return (getSubclassDataFromInstruction() & 3) != TCK_None;
+    unsigned Kind = getSubclassDataFromInstruction() & 3;
+    return Kind == TCK_Tail || Kind == TCK_MustTail;
   }
   bool isMustTailCall() const {
     return (getSubclassDataFromInstruction() & 3) == TCK_MustTail;
+  }
+  bool isNoTailCall() const {
+    return (getSubclassDataFromInstruction() & 3) == TCK_NoTail;
   }
   void setTailCall(bool isTC = true) {
     setInstructionSubclassData((getSubclassDataFromInstruction() & ~3) |

--- a/include/llvm/Target/TargetLowering.h
+++ b/include/llvm/Target/TargetLowering.h
@@ -939,15 +939,19 @@ public:
   }
 
   /// If a physical register, this returns the register that receives the
-  /// exception address on entry to a landing pad.
-  unsigned getExceptionPointerRegister() const {
-    return ExceptionPointerRegister;
+  /// exception address on entry to an EH pad.
+  virtual unsigned
+  getExceptionPointerRegister(const Constant *PersonalityFn) const {
+    // 0 is guaranteed to be the NoRegister value on all targets
+    return 0;
   }
 
   /// If a physical register, this returns the register that receives the
   /// exception typeid on entry to a landing pad.
-  unsigned getExceptionSelectorRegister() const {
-    return ExceptionSelectorRegister;
+  virtual unsigned
+  getExceptionSelectorRegister(const Constant *PersonalityFn) const {
+    // 0 is guaranteed to be the NoRegister value on all targets
+    return 0;
   }
 
   /// Returns the target's jmp_buf size in bytes (if never set, the default is
@@ -1226,18 +1230,6 @@ protected:
   /// llvm.savestack/llvm.restorestack should save and restore.
   void setStackPointerRegisterToSaveRestore(unsigned R) {
     StackPointerRegisterToSaveRestore = R;
-  }
-
-  /// If set to a physical register, this sets the register that receives the
-  /// exception address on entry to a landing pad.
-  void setExceptionPointerRegister(unsigned R) {
-    ExceptionPointerRegister = R;
-  }
-
-  /// If set to a physical register, this sets the register that receives the
-  /// exception typeid on entry to a landing pad.
-  void setExceptionSelectorRegister(unsigned R) {
-    ExceptionSelectorRegister = R;
   }
 
   /// Tells the code generator not to expand operations into sequences that use
@@ -1855,14 +1847,6 @@ private:
   /// If set to a physical register, this specifies the register that
   /// llvm.savestack/llvm.restorestack should save and restore.
   unsigned StackPointerRegisterToSaveRestore;
-
-  /// If set to a physical register, this specifies the register that receives
-  /// the exception address on entry to a landing pad.
-  unsigned ExceptionPointerRegister;
-
-  /// If set to a physical register, this specifies the register that receives
-  /// the exception typeid on entry to a landing pad.
-  unsigned ExceptionSelectorRegister;
 
   /// This indicates the default register class to use for each ValueType the
   /// target supports natively.

--- a/lib/Analysis/ScalarEvolutionExpander.cpp
+++ b/lib/Analysis/ScalarEvolutionExpander.cpp
@@ -101,11 +101,11 @@ static BasicBlock::iterator findInsertPointAfter(Instruction *I,
     if (isa<LandingPadInst>(IP) || isa<CleanupPadInst>(IP)) {
       ++IP;
     } else if (auto *TPI = dyn_cast<TerminatePadInst>(IP)) {
-      IP = TPI->getUnwindDest()->getFirstNonPHI();
+      IP = TPI->getUnwindDest()->getFirstNonPHI()->getIterator();
     } else if (auto *CEPI = dyn_cast<CatchEndPadInst>(IP)) {
-      IP = CEPI->getUnwindDest()->getFirstNonPHI();
+      IP = CEPI->getUnwindDest()->getFirstNonPHI()->getIterator();
     } else if (auto *CEPI = dyn_cast<CleanupEndPadInst>(IP)) {
-      IP = CEPI->getUnwindDest()->getFirstNonPHI();
+      IP = CEPI->getUnwindDest()->getFirstNonPHI()->getIterator();
     } else if (isa<CatchPadInst>(IP)) {
       IP = MustDominate->getFirstInsertionPt();
     } else {

--- a/lib/AsmParser/LLLexer.cpp
+++ b/lib/AsmParser/LLLexer.cpp
@@ -527,6 +527,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(caller);
   KEYWORD(tail);
   KEYWORD(musttail);
+  KEYWORD(notail);
   KEYWORD(target);
   KEYWORD(triple);
   KEYWORD(unwind);

--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -4830,6 +4830,7 @@ int LLParser::ParseInstruction(Instruction *&Inst, BasicBlock *BB,
   case lltok::kw_call:     return ParseCall(Inst, PFS, CallInst::TCK_None);
   case lltok::kw_tail:     return ParseCall(Inst, PFS, CallInst::TCK_Tail);
   case lltok::kw_musttail: return ParseCall(Inst, PFS, CallInst::TCK_MustTail);
+  case lltok::kw_notail:   return ParseCall(Inst, PFS, CallInst::TCK_NoTail);
   // Memory.
   case lltok::kw_alloca:         return ParseAlloc(Inst, PFS);
   case lltok::kw_load:           return ParseLoad(Inst, PFS);

--- a/lib/AsmParser/LLToken.h
+++ b/lib/AsmParser/LLToken.h
@@ -54,6 +54,7 @@ namespace lltok {
     kw_caller,
     kw_tail,
     kw_musttail,
+    kw_notail,
     kw_target,
     kw_triple,
     kw_unwind,

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4946,7 +4946,7 @@ std::error_code BitcodeReader::parseFunctionBody(Function *F) {
       unsigned CCInfo = Record[OpNum++];
 
       FunctionType *FTy = nullptr;
-      if (CCInfo >> 15 & 1 &&
+      if (CCInfo >> bitc::CALL_EXPLICIT_TYPE & 1 &&
           !(FTy = dyn_cast<FunctionType>(getTypeByID(Record[OpNum++]))))
         return error("Explicit call type is not a function type");
 
@@ -4996,12 +4996,14 @@ std::error_code BitcodeReader::parseFunctionBody(Function *F) {
       OperandBundles.clear();
       InstructionList.push_back(I);
       cast<CallInst>(I)->setCallingConv(
-          static_cast<CallingConv::ID>((0x7ff & CCInfo) >> 1));
+          static_cast<CallingConv::ID>((0x7ff & CCInfo) >> bitc::CALL_CCONV));
       CallInst::TailCallKind TCK = CallInst::TCK_None;
-      if (CCInfo & 1)
+      if (CCInfo & 1 << bitc::CALL_TAIL)
         TCK = CallInst::TCK_Tail;
-      if (CCInfo & (1 << 14))
+      if (CCInfo & (1 << bitc::CALL_MUSTTAIL))
         TCK = CallInst::TCK_MustTail;
+      if (CCInfo & (1 << bitc::CALL_NOTAIL))
+        TCK = CallInst::TCK_NoTail;
       cast<CallInst>(I)->setTailCallKind(TCK);
       cast<CallInst>(I)->setAttributes(PAL);
       break;

--- a/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1738,7 +1738,7 @@ static void WriteOperandBundles(BitstreamWriter &Stream, ImmutableCallSite CS,
   LLVMContext &C = CS.getInstruction()->getContext();
 
   for (unsigned i = 0, e = CS.getNumOperandBundles(); i != e; ++i) {
-    const auto &Bundle = CS.getOperandBundle(i);
+    const auto &Bundle = CS.getOperandBundleAt(i);
     Record.push_back(C.getOperandBundleTagID(Bundle.Tag));
 
     for (auto &Input : Bundle.Inputs)
@@ -2130,8 +2130,11 @@ static void WriteInstruction(const Instruction &I, unsigned InstID,
     Code = bitc::FUNC_CODE_INST_CALL;
 
     Vals.push_back(VE.getAttributeID(CI.getAttributes()));
-    Vals.push_back((CI.getCallingConv() << 1) | unsigned(CI.isTailCall()) |
-                   unsigned(CI.isMustTailCall()) << 14 | 1 << 15);
+    Vals.push_back(CI.getCallingConv() << bitc::CALL_CCONV |
+                   unsigned(CI.isTailCall()) << bitc::CALL_TAIL |
+                   unsigned(CI.isMustTailCall()) << bitc::CALL_MUSTTAIL |
+                   1 << bitc::CALL_EXPLICIT_TYPE |
+                   unsigned(CI.isNoTailCall()) << bitc::CALL_NOTAIL);
     Vals.push_back(VE.getTypeID(FTy));
     PushValueAndType(CI.getCalledValue(), InstID, Vals, VE);  // Callee
 

--- a/lib/CodeGen/MachineScheduler.cpp
+++ b/lib/CodeGen/MachineScheduler.cpp
@@ -989,15 +989,21 @@ void ScheduleDAGMILive::updatePressureDiffs(ArrayRef<unsigned> LiveUses) {
     for (const VReg2SUnit &V2SU
          : make_range(VRegUses.find(Reg), VRegUses.end())) {
       SUnit *SU = V2SU.SU;
-      DEBUG(dbgs() << "  UpdateRegP: SU(" << SU->NodeNum << ") "
-            << *SU->getInstr());
       // If this use comes before the reaching def, it cannot be a last use, so
       // descrease its pressure change.
       if (!SU->isScheduled && SU != &ExitSU) {
         LiveQueryResult LRQ
           = LI.Query(LIS->getInstructionIndex(SU->getInstr()));
-        if (LRQ.valueIn() == VNI)
-          getPressureDiff(SU).addPressureChange(Reg, true, &MRI);
+        if (LRQ.valueIn() == VNI) {
+          PressureDiff &PDiff = getPressureDiff(SU);
+          PDiff.addPressureChange(Reg, true, &MRI);
+          DEBUG(
+            dbgs() << "  UpdateRegP: SU(" << SU->NodeNum << ") "
+                   << *SU->getInstr();
+            dbgs() << "              to ";
+            PDiff.dump(*TRI);
+          );
+        }
       }
     }
   }
@@ -1029,8 +1035,16 @@ void ScheduleDAGMILive::schedule() {
   // This may initialize a DFSResult to be used for queue priority.
   SchedImpl->initialize(this);
 
-  DEBUG(for (unsigned su = 0, e = SUnits.size(); su != e; ++su)
-          SUnits[su].dumpAll(this));
+  DEBUG(
+    for (const SUnit &SU : SUnits) {
+      SU.dumpAll(this);
+      if (ShouldTrackPressure) {
+        dbgs() << "  Pressure Diff      : ";
+        getPressureDiff(&SU).dump(*TRI);
+      }
+      dbgs() << '\n';
+    }
+  );
   if (ViewMISchedDAGs) viewGraph();
 
   // Initialize ready queues now that the DAG and priority data are finalized.
@@ -1220,6 +1234,11 @@ void ScheduleDAGMILive::scheduleMI(SUnit *SU, bool IsTopNode) {
       // Update top scheduled pressure.
       TopRPTracker.advance();
       assert(TopRPTracker.getPos() == CurrentTop && "out of sync");
+      DEBUG(
+        dbgs() << "Top Pressure:\n";
+        dumpRegSetPressure(TopRPTracker.getRegSetPressureAtPos(), TRI);
+      );
+
       updateScheduledPressure(SU, TopRPTracker.getPressure().MaxSetPressure);
     }
   }
@@ -1242,6 +1261,11 @@ void ScheduleDAGMILive::scheduleMI(SUnit *SU, bool IsTopNode) {
       SmallVector<unsigned, 8> LiveUses;
       BotRPTracker.recede(&LiveUses);
       assert(BotRPTracker.getPos() == CurrentBottom && "out of sync");
+      DEBUG(
+        dbgs() << "Bottom Pressure:\n";
+        dumpRegSetPressure(BotRPTracker.getRegSetPressureAtPos(), TRI);
+      );
+
       updateScheduledPressure(SU, BotRPTracker.getPressure().MaxSetPressure);
       updatePressureDiffs(LiveUses);
     }

--- a/lib/CodeGen/PostRASchedulerList.cpp
+++ b/lib/CodeGen/PostRASchedulerList.cpp
@@ -399,8 +399,12 @@ void SchedulePostRATDList::schedule() {
   }
 
   DEBUG(dbgs() << "********** List Scheduling **********\n");
-  DEBUG(for (unsigned su = 0, e = SUnits.size(); su != e; ++su)
-          SUnits[su].dumpAll(this));
+  DEBUG(
+    for (const SUnit &SU : SUnits) {
+      SU.dumpAll(this);
+      dbgs() << '\n';
+    }
+  );
 
   AvailableQueue.initNodes(SUnits);
   ListScheduleTopDown();

--- a/lib/CodeGen/ScheduleDAG.cpp
+++ b/lib/CodeGen/ScheduleDAG.cpp
@@ -372,7 +372,6 @@ void SUnit::dumpAll(const ScheduleDAG *G) const {
       dbgs() << "\n";
     }
   }
-  dbgs() << "\n";
 }
 #endif
 

--- a/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -3206,7 +3206,8 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
         // be expensive (and would be wrong if the type is not byte sized).
         if (!LN0->isVolatile() && LoadedVT.bitsGT(ExtVT) && ExtVT.isRound() &&
             (!LegalOperations || TLI.isLoadExtLegal(ISD::ZEXTLOAD, LoadResultTy,
-                                                    ExtVT))) {
+                                                    ExtVT)) &&
+            TLI.shouldReduceLoadWidth(LN0, ISD::ZEXTLOAD, ExtVT)) {
           EVT PtrType = LN0->getOperand(1).getValueType();
 
           unsigned Alignment = LN0->getAlignment();

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -2184,8 +2184,9 @@ void SelectionDAGBuilder::visitLandingPad(const LandingPadInst &LP) {
   // If there aren't registers to copy the values into (e.g., during SjLj
   // exceptions), then don't bother to create these DAG nodes.
   const TargetLowering &TLI = DAG.getTargetLoweringInfo();
-  if (TLI.getExceptionPointerRegister() == 0 &&
-      TLI.getExceptionSelectorRegister() == 0)
+  const Constant *PersonalityFn = FuncInfo.Fn->getPersonalityFn();
+  if (TLI.getExceptionPointerRegister(PersonalityFn) == 0 &&
+      TLI.getExceptionSelectorRegister(PersonalityFn) == 0)
     return;
 
   SmallVector<EVT, 2> ValueVTs;

--- a/lib/CodeGen/TargetLoweringBase.cpp
+++ b/lib/CodeGen/TargetLoweringBase.cpp
@@ -765,8 +765,6 @@ TargetLoweringBase::TargetLoweringBase(const TargetMachine &tm) : TM(tm) {
   EnableExtLdPromotion = false;
   HasFloatingPointExceptions = true;
   StackPointerRegisterToSaveRestore = 0;
-  ExceptionPointerRegister = 0;
-  ExceptionSelectorRegister = 0;
   BooleanContents = UndefinedBooleanContent;
   BooleanFloatContents = UndefinedBooleanContent;
   BooleanVectorContents = UndefinedBooleanContent;

--- a/lib/IR/AsmWriter.cpp
+++ b/lib/IR/AsmWriter.cpp
@@ -2169,7 +2169,7 @@ void AssemblyWriter::writeOperandBundles(ImmutableCallSite CS) {
 
   bool FirstBundle = true;
   for (unsigned i = 0, e = CS.getNumOperandBundles(); i != e; ++i) {
-    OperandBundleUse BU = CS.getOperandBundle(i);
+    OperandBundleUse BU = CS.getOperandBundleAt(i);
 
     if (!FirstBundle)
       Out << ", ";
@@ -2768,6 +2768,8 @@ void AssemblyWriter::printInstruction(const Instruction &I) {
       Out << "musttail ";
     else if (CI->isTailCall())
       Out << "tail ";
+    else if (CI->isNoTailCall())
+      Out << "notail ";
   }
 
   // Print out the opcode...

--- a/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/lib/Target/AArch64/AArch64FastISel.cpp
@@ -2451,6 +2451,10 @@ bool AArch64FastISel::selectIndirectBr(const Instruction *I) {
 bool AArch64FastISel::selectCmp(const Instruction *I) {
   const CmpInst *CI = cast<CmpInst>(I);
 
+  // Vectors of i1 are weird: bail out.
+  if (CI->getType()->isVectorTy())
+    return false;
+
   // Try to optimize or fold the cmp.
   CmpInst::Predicate Predicate = optimizeCmpPredicate(CI);
   unsigned ResultReg = 0;

--- a/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -196,11 +196,6 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::STACKRESTORE, MVT::Other, Expand);
   setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i64, Expand);
 
-  // Exception handling.
-  // FIXME: These are guesses. Has this been defined yet?
-  setExceptionPointerRegister(AArch64::X0);
-  setExceptionSelectorRegister(AArch64::X1);
-
   // Constant pool entries
   setOperationAction(ISD::ConstantPool, MVT::i64, Custom);
 

--- a/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/lib/Target/AArch64/AArch64ISelLowering.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_LIB_TARGET_AARCH64_AARCH64ISELLOWERING_H
 #define LLVM_LIB_TARGET_AARCH64_AARCH64ISELLOWERING_H
 
+#include "AArch64.h"
 #include "llvm/CodeGen/CallingConvLower.h"
 #include "llvm/CodeGen/SelectionDAG.h"
 #include "llvm/IR/CallingConv.h"
@@ -365,6 +366,22 @@ public:
   /// If the target has a standard location for the unsafe stack pointer,
   /// returns the address of that location. Otherwise, returns nullptr.
   Value *getSafeStackPointerLocation(IRBuilder<> &IRB) const override;
+
+  /// If a physical register, this returns the register that receives the
+  /// exception address on entry to an EH pad.
+  unsigned
+  getExceptionPointerRegister(const Constant *PersonalityFn) const override {
+    // FIXME: This is a guess. Has this been defined yet?
+    return AArch64::X0;
+  }
+
+  /// If a physical register, this returns the register that receives the
+  /// exception typeid on entry to a landing pad.
+  unsigned
+  getExceptionSelectorRegister(const Constant *PersonalityFn) const override {
+    // FIXME: This is a guess. Has this been defined yet?
+    return AArch64::X1;
+  }
 
 private:
   bool isExtFreeImpl(const Instruction *Ext) const override;

--- a/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1351,20 +1351,22 @@ class VOP1_Real_vi <string opName, vop1 op, dag outs, dag ins, string asm> :
   let AssemblerPredicates = [isVI];
 }
 
-multiclass VOP1_m <vop1 op, dag outs, dag ins, string asm, list<dag> pattern,
-                   string opName> {
-  def "" : VOP1_Pseudo <outs, ins, pattern, opName>;
+multiclass VOP1_m <vop1 op, string opName, VOPProfile p, list<dag> pattern,
+                   string asm = opName#p.Asm32> {
+  def "" : VOP1_Pseudo <p.Outs, p.Ins32, pattern, opName>;
 
-  def _si : VOP1_Real_si <opName, op, outs, ins, asm>;
+  def _si : VOP1_Real_si <opName, op, p.Outs, p.Ins32, asm>;
 
-  def _vi : VOP1_Real_vi <opName, op, outs, ins, asm>;
+  def _vi : VOP1_Real_vi <opName, op, p.Outs, p.Ins32, asm>;
+
 }
 
-multiclass VOP1SI_m <vop1 op, dag outs, dag ins, string asm, list<dag> pattern,
-                   string opName> {
-  def "" : VOP1_Pseudo <outs, ins, pattern, opName>;
+multiclass VOP1SI_m <vop1 op, string opName, VOPProfile p, list<dag> pattern,
+                     string asm = opName#p.Asm32> {
 
-  def _si : VOP1_Real_si <opName, op, outs, ins, asm>;
+  def "" : VOP1_Pseudo <p.Outs, p.Ins32, pattern, opName>;
+
+  def _si : VOP1_Real_si <opName, op, p.Outs, p.Ins32, asm>;
 }
 
 class VOP2_Pseudo <dag outs, dag ins, list<dag> pattern, string opName> :
@@ -1388,22 +1390,24 @@ class VOP2_Real_vi <string opName, vop2 op, dag outs, dag ins, string asm> :
   let AssemblerPredicates = [isVI];
 }
 
-multiclass VOP2SI_m <vop2 op, dag outs, dag ins, string asm, list<dag> pattern,
-                     string opName, string revOp> {
-  def "" : VOP2_Pseudo <outs, ins, pattern, opName>,
+multiclass VOP2SI_m <vop2 op, string opName, VOPProfile p, list<dag> pattern,
+                     string revOp> {
+
+  def "" : VOP2_Pseudo <p.Outs32, p.Ins32, pattern, opName>,
            VOP2_REV<revOp#"_e32", !eq(revOp, opName)>;
 
-  def _si : VOP2_Real_si <opName, op, outs, ins, asm>;
+  def _si : VOP2_Real_si <opName, op, p.Outs32, p.Ins32, p.Asm32>;
 }
 
-multiclass VOP2_m <vop2 op, dag outs, dag ins, string asm, list<dag> pattern,
-                   string opName, string revOp> {
-  def "" : VOP2_Pseudo <outs, ins, pattern, opName>,
+multiclass VOP2_m <vop2 op, string opName, VOPProfile p, list <dag> pattern,
+                   string revOp> {
+
+  def "" : VOP2_Pseudo <p.Outs32, p.Ins32, pattern, opName>,
            VOP2_REV<revOp#"_e32", !eq(revOp, opName)>;
 
-  def _si : VOP2_Real_si <opName, op, outs, ins, asm>;
+  def _si : VOP2_Real_si <opName, op, p.Outs32, p.Ins32, p.Asm32>;
 
-  def _vi : VOP2_Real_vi <opName, op, outs, ins, asm>;
+  def _vi : VOP2_Real_vi <opName, op, p.Outs32, p.Ins32, p.Asm32>;
 
 }
 
@@ -1592,32 +1596,28 @@ multiclass VOP2SI_3VI_m <vop3 op, string opName, dag outs, dag ins,
   }
 }
 
-multiclass VOP1_Helper <vop1 op, string opName, dag outs,
-                        dag ins32, string asm32, list<dag> pat32,
-                        dag ins64, string asm64, list<dag> pat64,
-                        bit HasMods> {
+multiclass VOP1_Helper <vop1 op, string opName, VOPProfile p, list<dag> pat32,
+                        list<dag> pat64> {
 
-  defm _e32 : VOP1_m <op, outs, ins32, opName#asm32, pat32, opName>;
+  defm _e32 : VOP1_m <op, opName, p, pat32>;
 
-  defm _e64 : VOP3_1_m <op, outs, ins64, opName#asm64, pat64, opName, HasMods>;
+  defm _e64 : VOP3_1_m <op, p.Outs, p.Ins64, opName#p.Asm64, pat64, opName,
+                        p.HasModifiers>;
 }
 
 multiclass VOP1Inst <vop1 op, string opName, VOPProfile P,
                      SDPatternOperator node = null_frag> : VOP1_Helper <
-  op, opName, P.Outs,
-  P.Ins32, P.Asm32, [],
-  P.Ins64, P.Asm64,
+  op, opName, P, [],
   !if(P.HasModifiers,
       [(set P.DstVT:$dst, (node (P.Src0VT (VOP3Mods0 P.Src0VT:$src0,
                                 i32:$src0_modifiers, i1:$clamp, i32:$omod))))],
-      [(set P.DstVT:$dst, (node P.Src0VT:$src0))]),
-  P.HasModifiers
+      [(set P.DstVT:$dst, (node P.Src0VT:$src0))])
 >;
 
 multiclass VOP1InstSI <vop1 op, string opName, VOPProfile P,
                        SDPatternOperator node = null_frag> {
 
-  defm _e32 : VOP1SI_m <op, P.Outs, P.Ins32, opName#P.Asm32, [], opName>;
+  defm _e32 : VOP1SI_m <op, opName, P, []>;
 
   defm _e64 : VOP3SI_1_m <op, P.Outs, P.Ins64, opName#P.Asm64,
     !if(P.HasModifiers,
@@ -1627,36 +1627,33 @@ multiclass VOP1InstSI <vop1 op, string opName, VOPProfile P,
     opName, P.HasModifiers>;
 }
 
-multiclass VOP2_Helper <vop2 op, string opName, dag outs,
-                        dag ins32, string asm32, list<dag> pat32,
-                        dag ins64, string asm64, list<dag> pat64,
-                        string revOp, bit HasMods> {
-  defm _e32 : VOP2_m <op, outs, ins32, asm32, pat32, opName, revOp>;
+multiclass VOP2_Helper <vop2 op, string opName, VOPProfile p, list<dag> pat32,
+                        list<dag> pat64, string revOp> {
 
-  defm _e64 : VOP3_2_m <op,
-    outs, ins64, opName#asm64, pat64, opName, revOp, HasMods
-  >;
+  defm _e32 : VOP2_m <op, opName, p, pat32, revOp>;
+
+  defm _e64 : VOP3_2_m <op, p.Outs, p.Ins64, opName#p.Asm64, pat64, opName,
+                        revOp, p.HasModifiers>;
 }
 
 multiclass VOP2Inst <vop2 op, string opName, VOPProfile P,
                      SDPatternOperator node = null_frag,
                      string revOp = opName> : VOP2_Helper <
-  op, opName, P.Outs,
-  P.Ins32, P.Asm32, [],
-  P.Ins64, P.Asm64,
+  op, opName, P, [],
   !if(P.HasModifiers,
       [(set P.DstVT:$dst,
            (node (P.Src0VT (VOP3Mods0 P.Src0VT:$src0, i32:$src0_modifiers,
                                       i1:$clamp, i32:$omod)),
                  (P.Src1VT (VOP3Mods P.Src1VT:$src1, i32:$src1_modifiers))))],
       [(set P.DstVT:$dst, (node P.Src0VT:$src0, P.Src1VT:$src1))]),
-  revOp, P.HasModifiers
+  revOp
 >;
 
 multiclass VOP2InstSI <vop2 op, string opName, VOPProfile P,
                        SDPatternOperator node = null_frag,
                        string revOp = opName> {
-  defm _e32 : VOP2SI_m <op, P.Outs, P.Ins32, P.Asm32, [], opName, revOp>;
+
+  defm _e32 : VOP2SI_m <op, opName, P, [], revOp>;
 
   defm _e64 : VOP3SI_2_m <op, P.Outs, P.Ins64, opName#P.Asm64,
     !if(P.HasModifiers,
@@ -1668,61 +1665,55 @@ multiclass VOP2InstSI <vop2 op, string opName, VOPProfile P,
     opName, revOp, P.HasModifiers>;
 }
 
-multiclass VOP2b_Helper <vop2 op, string opName, dag outs32, dag outs64,
-                         dag ins32, string asm32, list<dag> pat32,
-                         dag ins64, string asm64, list<dag> pat64,
-                         string revOp, bit HasMods, bit useSGPRInput> {
+multiclass VOP2b_Helper <vop2 op, string opName, VOPProfile p,
+                         list<dag> pat32, list<dag> pat64,
+                         string revOp, bit useSGPRInput> {
+
   let SchedRW = [Write32Bit, WriteSALU] in {
     let Uses = !if(useSGPRInput, [VCC, EXEC], [EXEC]), Defs = [VCC] in {
-      defm _e32 : VOP2_m <op, outs32, ins32, asm32, pat32, opName, revOp>;
+      defm _e32 : VOP2_m <op, opName, p, pat32, revOp>;
     }
 
-    defm _e64 : VOP3b_2_3_m <op,
-      outs64, ins64, opName#asm64, pat64, opName, revOp, HasMods, useSGPRInput
-    >;
+    defm _e64 : VOP3b_2_3_m <op, p.Outs64, p.Ins64, opName#p.Asm64, pat64,
+                             opName, revOp, p.HasModifiers, useSGPRInput>;
   }
 }
 
 multiclass VOP2bInst <vop2 op, string opName, VOPProfile P,
                       SDPatternOperator node = null_frag,
                       string revOp = opName> : VOP2b_Helper <
-  op, opName, P.Outs32, P.Outs64,
-  P.Ins32, P.Asm32, [],
-  P.Ins64, P.Asm64,
+  op, opName, P, [],
   !if(P.HasModifiers,
       [(set P.DstVT:$dst,
            (node (P.Src0VT (VOP3Mods0 P.Src0VT:$src0, i32:$src0_modifiers,
                                       i1:$clamp, i32:$omod)),
                  (P.Src1VT (VOP3Mods P.Src1VT:$src1, i32:$src1_modifiers))))],
       [(set P.DstVT:$dst, (node P.Src0VT:$src0, P.Src1VT:$src1))]),
-  revOp, P.HasModifiers, !eq(P.NumSrcArgs, 3)
+  revOp, !eq(P.NumSrcArgs, 3)
 >;
 
 // A VOP2 instruction that is VOP3-only on VI.
-multiclass VOP2_VI3_Helper <vop23 op, string opName, dag outs,
-                            dag ins32, string asm32, list<dag> pat32,
-                            dag ins64, string asm64, list<dag> pat64,
-                            string revOp, bit HasMods> {
-  defm _e32 : VOP2SI_m <op, outs, ins32, asm32, pat32, opName, revOp>;
+multiclass VOP2_VI3_Helper <vop23 op, string opName, VOPProfile p,
+                            list<dag> pat32, list<dag> pat64, string revOp> {
 
-  defm _e64 : VOP3_2_m <op, outs, ins64, opName#asm64, pat64, opName,
-                        revOp, HasMods>;
+  defm _e32 : VOP2SI_m <op, opName, p, pat32, revOp>;
+
+  defm _e64 : VOP3_2_m <op, p.Outs, p.Ins64, opName#p.Asm64, pat64, opName,
+                        revOp, p.HasModifiers>;
 }
 
 multiclass VOP2_VI3_Inst <vop23 op, string opName, VOPProfile P,
                           SDPatternOperator node = null_frag,
                           string revOp = opName>
                           : VOP2_VI3_Helper <
-  op, opName, P.Outs,
-  P.Ins32, P.Asm32, [],
-  P.Ins64, P.Asm64,
+  op, opName, P, [],
   !if(P.HasModifiers,
       [(set P.DstVT:$dst,
            (node (P.Src0VT (VOP3Mods0 P.Src0VT:$src0, i32:$src0_modifiers,
                                       i1:$clamp, i32:$omod)),
                  (P.Src1VT (VOP3Mods P.Src1VT:$src1, i32:$src1_modifiers))))],
       [(set P.DstVT:$dst, (node P.Src0VT:$src0, P.Src1VT:$src1))]),
-  revOp, P.HasModifiers
+  revOp
 >;
 
 multiclass VOP2MADK <vop2 op, string opName, list<dag> pattern = []> {
@@ -1787,31 +1778,24 @@ multiclass VOPC_m <vopc op, dag ins, string op_asm, list<dag> pattern,
   defm : SIInstAliasBuilder<alias_asm, p>;
 }
 
-multiclass VOPC_Helper <vopc op, string opName,
-                        dag ins32, string asm32, list<dag> pat32,
-                        dag out64, dag ins64, string asm64, list<dag> pat64,
-                        bit HasMods, bit DefExec, string revOp,
-                        VOPProfile p,
-                        list<SchedReadWrite> sched> {
-  defm _e32 : VOPC_m <op, ins32, asm32, pat32, opName, DefExec, p, sched>;
+multiclass VOPC_Helper <vopc op, string opName, list<dag> pat32,
+                        list<dag> pat64, bit DefExec, string revOp,
+                        VOPProfile p, list<SchedReadWrite> sched> {
+  defm _e32 : VOPC_m <op, p.Ins32, p.Asm32, pat32, opName, DefExec, p, sched>;
 
-  defm _e64 : VOP3_C_m <op, out64, ins64, opName#asm64, pat64,
-                        opName, HasMods, DefExec, revOp,
-                        sched>;
+  defm _e64 : VOP3_C_m <op, (outs VOPDstS64:$dst), p.Ins64, opName#p.Asm64, pat64,
+                        opName, p.HasModifiers, DefExec, revOp, sched>;
 }
 
 // Special case for class instructions which only have modifiers on
 // the 1st source operand.
-multiclass VOPC_Class_Helper <vopc op, string opName,
-                             dag ins32, string asm32, list<dag> pat32,
-                             dag out64, dag ins64, string asm64, list<dag> pat64,
-                             bit HasMods, bit DefExec, string revOp,
-                             VOPProfile p,
-                             list<SchedReadWrite> sched> {
-  defm _e32 : VOPC_m <op, ins32, asm32, pat32, opName, DefExec, p, sched>;
+multiclass VOPC_Class_Helper <vopc op, string opName, list<dag> pat32,
+                              list<dag> pat64, bit DefExec, string revOp,
+                              VOPProfile p, list<SchedReadWrite> sched> {
+  defm _e32 : VOPC_m <op, p.Ins32, p.Asm32, pat32, opName, DefExec, p, sched>;
 
-  defm _e64 : VOP3_C_m <op, out64, ins64, opName#asm64, pat64,
-                        opName, HasMods, DefExec, revOp, sched>,
+  defm _e64 : VOP3_C_m <op, (outs VOPDstS64:$dst), p.Ins64, opName#p.Asm64, pat64,
+                        opName, p.HasModifiers, DefExec, revOp, sched>,
                         VOP3DisableModFields<1, 0, 0>;
 }
 
@@ -1821,9 +1805,7 @@ multiclass VOPCInst <vopc op, string opName,
                      bit DefExec = 0,
                      list<SchedReadWrite> sched = [Write32Bit]> :
                      VOPC_Helper <
-  op, opName,
-  P.Ins32, P.Asm32, [],
-  (outs VOPDstS64:$dst), P.Ins64, P.Asm64,
+  op, opName, [],
   !if(P.HasModifiers,
       [(set i1:$dst,
           (setcc (P.Src0VT (VOP3Mods0 P.Src0VT:$src0, i32:$src0_modifiers,
@@ -1831,20 +1813,18 @@ multiclass VOPCInst <vopc op, string opName,
                  (P.Src1VT (VOP3Mods P.Src1VT:$src1, i32:$src1_modifiers)),
                  cond))],
       [(set i1:$dst, (setcc P.Src0VT:$src0, P.Src1VT:$src1, cond))]),
-  P.HasModifiers, DefExec, revOp, P, sched
+  DefExec, revOp, P, sched
 >;
 
 multiclass VOPCClassInst <vopc op, string opName, VOPProfile P,
                      bit DefExec = 0,
                      list<SchedReadWrite> sched> : VOPC_Class_Helper <
-  op, opName,
-  P.Ins32, P.Asm32, [],
-  (outs VOPDstS64:$dst), P.Ins64, P.Asm64,
+  op, opName, [],
   !if(P.HasModifiers,
       [(set i1:$dst,
           (AMDGPUfp_class (P.Src0VT (VOP3Mods0Clamp0OMod P.Src0VT:$src0, i32:$src0_modifiers)), P.Src1VT:$src1))],
       [(set i1:$dst, (AMDGPUfp_class P.Src0VT:$src0, P.Src1VT:$src1))]),
-  P.HasModifiers, DefExec, opName, P, sched
+  DefExec, opName, P, sched
 >;
 
 

--- a/lib/Target/AMDGPU/SIInstructions.td
+++ b/lib/Target/AMDGPU/SIInstructions.td
@@ -1431,9 +1431,7 @@ defm V_INTERP_MOV_F32 : VINTRP_m <
 //===----------------------------------------------------------------------===//
 
 multiclass V_CNDMASK <vop2 op, string name> {
-  defm _e32 : VOP2_m <
-      op, VOP_CNDMASK.Outs, VOP_CNDMASK.Ins32, VOP_CNDMASK.Asm32, [],
-      name, name>;
+  defm _e32 : VOP2_m <op, name, VOP_CNDMASK, [], name>;
 
   defm _e64  : VOP3_m <
       op, VOP_CNDMASK.Outs, VOP_CNDMASK.Ins64,

--- a/lib/Target/ARM/ARMISelLowering.cpp
+++ b/lib/Target/ARM/ARMISelLowering.cpp
@@ -813,13 +813,6 @@ ARMTargetLowering::ARMTargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::STACKSAVE,          MVT::Other, Expand);
   setOperationAction(ISD::STACKRESTORE,       MVT::Other, Expand);
 
-  if (!Subtarget->useSjLjEH()) {
-    // Platforms which do not use SjLj EH may return values in these registers
-    // via the personality function.
-    setExceptionPointerRegister(ARM::R0);
-    setExceptionSelectorRegister(ARM::R1);
-  }
-
   if (Subtarget->getTargetTriple().isWindowsItaniumEnvironment())
     setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i32, Custom);
   else
@@ -12146,4 +12139,18 @@ bool ARMTargetLowering::functionArgumentNeedsConsecutiveRegisters(
 
   bool IsIntArray = Ty->isArrayTy() && Ty->getArrayElementType()->isIntegerTy();
   return IsHA || IsIntArray;
+}
+
+unsigned ARMTargetLowering::getExceptionPointerRegister(
+    const Constant *PersonalityFn) const {
+  // Platforms which do not use SjLj EH may return values in these registers
+  // via the personality function.
+  return Subtarget->useSjLjEH() ? ARM::NoRegister : ARM::R0;
+}
+
+unsigned ARMTargetLowering::getExceptionSelectorRegister(
+    const Constant *PersonalityFn) const {
+  // Platforms which do not use SjLj EH may return values in these registers
+  // via the personality function.
+  return Subtarget->useSjLjEH() ? ARM::NoRegister : ARM::R1;
 }

--- a/lib/Target/ARM/ARMISelLowering.h
+++ b/lib/Target/ARM/ARMISelLowering.h
@@ -423,6 +423,16 @@ namespace llvm {
     bool functionArgumentNeedsConsecutiveRegisters(
         Type *Ty, CallingConv::ID CallConv, bool isVarArg) const override;
 
+    /// If a physical register, this returns the register that receives the
+    /// exception address on entry to an EH pad.
+    unsigned
+    getExceptionPointerRegister(const Constant *PersonalityFn) const override;
+
+    /// If a physical register, this returns the register that receives the
+    /// exception typeid on entry to a landing pad.
+    unsigned
+    getExceptionSelectorRegister(const Constant *PersonalityFn) const override;
+
     Instruction *makeDMB(IRBuilder<> &Builder, ARM_MB::MemBOpt Domain) const;
     Value *emitLoadLinked(IRBuilder<> &Builder, Value *Addr,
                           AtomicOrdering Ord) const override;

--- a/lib/Target/Hexagon/BitTracker.cpp
+++ b/lib/Target/Hexagon/BitTracker.cpp
@@ -1106,7 +1106,7 @@ void BT::run() {
     if (It == End) {
       MachineFunction::const_iterator BIt = B.getIterator();
       MachineFunction::const_iterator Next = std::next(BIt);
-      if (Next != MF.end() && B.isSuccessor(Next)) {
+      if (Next != MF.end() && B.isSuccessor(&*Next)) {
         int ThisN = B.getNumber();
         int NextN = Next->getNumber();
         FlowQ.push(CFGEdge(ThisN, NextN));

--- a/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -1286,8 +1286,6 @@ HexagonTargetLowering::HexagonTargetLowering(const TargetMachine &TM,
   setPrefFunctionAlignment(4);
   setMinFunctionAlignment(2);
   setInsertFencesForAtomic(false);
-  setExceptionPointerRegister(Hexagon::R0);
-  setExceptionSelectorRegister(Hexagon::R1);
   setStackPointerRegisterToSaveRestore(HRI.getStackRegister());
 
   if (EnableHexSDNodeSched)

--- a/lib/Target/Hexagon/HexagonISelLowering.h
+++ b/lib/Target/Hexagon/HexagonISelLowering.h
@@ -163,6 +163,20 @@ bool isPositiveHalfWord(SDNode *N);
     MachineBasicBlock * EmitInstrWithCustomInserter(MachineInstr *MI,
         MachineBasicBlock *BB) const override;
 
+    /// If a physical register, this returns the register that receives the
+    /// exception address on entry to an EH pad.
+    unsigned
+    getExceptionPointerRegister(const Constant *PersonalityFn) const override {
+      return Hexagon::R0;
+    }
+
+    /// If a physical register, this returns the register that receives the
+    /// exception typeid on entry to a landing pad.
+    unsigned
+    getExceptionSelectorRegister(const Constant *PersonalityFn) const override {
+      return Hexagon::R1;
+    }
+
     SDValue LowerVASTART(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerConstantPool(SDValue Op, SelectionDAG &DAG) const;
     EVT getSetCCResultType(const DataLayout &, LLVMContext &C,

--- a/lib/Target/Mips/MipsISelLowering.cpp
+++ b/lib/Target/Mips/MipsISelLowering.cpp
@@ -438,9 +438,6 @@ MipsTargetLowering::MipsTargetLowering(const MipsTargetMachine &TM,
 
   setStackPointerRegisterToSaveRestore(ABI.IsN64() ? Mips::SP_64 : Mips::SP);
 
-  setExceptionPointerRegister(ABI.IsN64() ? Mips::A0_64 : Mips::A0);
-  setExceptionSelectorRegister(ABI.IsN64() ? Mips::A1_64 : Mips::A1);
-
   MaxStoresPerMemcpy = 16;
 
   isMicroMips = Subtarget.inMicroMipsMode();

--- a/lib/Target/Mips/MipsISelLowering.h
+++ b/lib/Target/Mips/MipsISelLowering.h
@@ -267,6 +267,20 @@ namespace llvm {
     unsigned getRegisterByName(const char* RegName, EVT VT,
                                SelectionDAG &DAG) const override;
 
+    /// If a physical register, this returns the register that receives the
+    /// exception address on entry to an EH pad.
+    unsigned
+    getExceptionPointerRegister(const Constant *PersonalityFn) const override {
+      return ABI.IsN64() ? Mips::A0_64 : Mips::A0;
+    }
+
+    /// If a physical register, this returns the register that receives the
+    /// exception typeid on entry to a landing pad.
+    unsigned
+    getExceptionSelectorRegister(const Constant *PersonalityFn) const override {
+      return ABI.IsN64() ? Mips::A1_64 : Mips::A1;
+    }
+
     /// Returns true if a cast between SrcAS and DestAS is a noop.
     bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override {
       // Mips doesn't have any special address spaces so we just reserve

--- a/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -827,15 +827,7 @@ PPCTargetLowering::PPCTargetLowering(const PPCTargetMachine &TM,
     setLibcallName(RTLIB::SRA_I128, nullptr);
   }
 
-  if (isPPC64) {
-    setStackPointerRegisterToSaveRestore(PPC::X1);
-    setExceptionPointerRegister(PPC::X3);
-    setExceptionSelectorRegister(PPC::X4);
-  } else {
-    setStackPointerRegisterToSaveRestore(PPC::R1);
-    setExceptionPointerRegister(PPC::R3);
-    setExceptionSelectorRegister(PPC::R4);
-  }
+  setStackPointerRegisterToSaveRestore(isPPC64 ? PPC::X1 : PPC::R1);
 
   // We have target-specific dag combine patterns for the following nodes:
   setTargetDAGCombine(ISD::SINT_TO_FP);
@@ -11530,6 +11522,16 @@ PPCTargetLowering::getScratchRegisters(CallingConv::ID) const {
   };
 
   return ScratchRegs;
+}
+
+unsigned PPCTargetLowering::getExceptionPointerRegister(
+    const Constant *PersonalityFn) const {
+  return Subtarget.isPPC64() ? PPC::X3 : PPC::R3;
+}
+
+unsigned PPCTargetLowering::getExceptionSelectorRegister(
+    const Constant *PersonalityFn) const {
+  return Subtarget.isPPC64() ? PPC::X4 : PPC::R4;
 }
 
 bool

--- a/lib/Target/PowerPC/PPCISelLowering.h
+++ b/lib/Target/PowerPC/PPCISelLowering.h
@@ -655,8 +655,17 @@ namespace llvm {
       return Ty->isArrayTy();
     }
 
-  private:
+    /// If a physical register, this returns the register that receives the
+    /// exception address on entry to an EH pad.
+    unsigned
+    getExceptionPointerRegister(const Constant *PersonalityFn) const override;
 
+    /// If a physical register, this returns the register that receives the
+    /// exception typeid on entry to a landing pad.
+    unsigned
+    getExceptionSelectorRegister(const Constant *PersonalityFn) const override;
+
+  private:
     struct ReuseLoadInfo {
       SDValue Ptr;
       SDValue Chain;

--- a/lib/Target/Sparc/SparcISelLowering.cpp
+++ b/lib/Target/Sparc/SparcISelLowering.cpp
@@ -1674,9 +1674,6 @@ SparcTargetLowering::SparcTargetLowering(TargetMachine &TM,
   setOperationAction(ISD::STACKRESTORE      , MVT::Other, Expand);
   setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i32  , Custom);
 
-  setExceptionPointerRegister(SP::I0);
-  setExceptionSelectorRegister(SP::I1);
-
   setStackPointerRegisterToSaveRestore(SP::O6);
 
   setOperationAction(ISD::CTPOP, MVT::i32,

--- a/lib/Target/Sparc/SparcISelLowering.h
+++ b/lib/Target/Sparc/SparcISelLowering.h
@@ -89,6 +89,20 @@ namespace llvm {
       return MVT::i32;
     }
 
+    /// If a physical register, this returns the register that receives the
+    /// exception address on entry to an EH pad.
+    unsigned
+    getExceptionPointerRegister(const Constant *PersonalityFn) const override {
+      return SP::I0;
+    }
+
+    /// If a physical register, this returns the register that receives the
+    /// exception typeid on entry to a landing pad.
+    unsigned
+    getExceptionSelectorRegister(const Constant *PersonalityFn) const override {
+      return SP::I1;
+    }
+
     /// getSetCCResultType - Return the ISD::SETCC ValueType
     EVT getSetCCResultType(const DataLayout &DL, LLVMContext &Context,
                            EVT VT) const override;

--- a/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -114,8 +114,6 @@ SystemZTargetLowering::SystemZTargetLowering(const TargetMachine &TM,
   computeRegisterProperties(Subtarget.getRegisterInfo());
 
   // Set up special registers.
-  setExceptionPointerRegister(SystemZ::R6D);
-  setExceptionSelectorRegister(SystemZ::R7D);
   setStackPointerRegisterToSaveRestore(SystemZ::R15D);
 
   // TODO: It may be better to default to latency-oriented scheduling, however

--- a/lib/Target/SystemZ/SystemZISelLowering.h
+++ b/lib/Target/SystemZ/SystemZISelLowering.h
@@ -409,6 +409,20 @@ public:
     return TargetLowering::getInlineAsmMemConstraint(ConstraintCode);
   }
 
+  /// If a physical register, this returns the register that receives the
+  /// exception address on entry to an EH pad.
+  unsigned
+  getExceptionPointerRegister(const Constant *PersonalityFn) const override {
+    return SystemZ::R6D;
+  }
+
+  /// If a physical register, this returns the register that receives the
+  /// exception typeid on entry to a landing pad.
+  unsigned
+  getExceptionSelectorRegister(const Constant *PersonalityFn) const override {
+    return SystemZ::R7D;
+  }
+
   MachineBasicBlock *EmitInstrWithCustomInserter(MachineInstr *MI,
                                                  MachineBasicBlock *BB) const
     override;

--- a/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
+++ b/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
@@ -154,7 +154,7 @@ static void SortBlocks(MachineFunction &MF, const MachineLoopInfo &MLI) {
   SmallPtrSet<MachineBasicBlock *, 16> Visited;
   SmallVector<POStackEntry, 16> Stack;
 
-  MachineBasicBlock *Entry = MF.begin();
+  MachineBasicBlock *Entry = &*MF.begin();
   Visited.insert(Entry);
   Stack.push_back(POStackEntry(Entry, MF, MLI));
 
@@ -170,7 +170,7 @@ static void SortBlocks(MachineFunction &MF, const MachineLoopInfo &MLI) {
 
     // Put the block in its position in the MachineFunction.
     MachineBasicBlock &MBB = *Entry.MBB;
-    MBB.moveBefore(MF.begin());
+    MBB.moveBefore(&*MF.begin());
 
     // Branch instructions may utilize a fallthrough, so update them if a
     // fallthrough has been added or removed.
@@ -196,7 +196,7 @@ static void SortBlocks(MachineFunction &MF, const MachineLoopInfo &MLI) {
       assert(Loop->getHeader() == Loop->getTopBlock());
       assert((Loop->getHeader() == &MBB ||
               Loop->contains(
-                  MLI.getLoopFor(prev(MachineFunction::iterator(&MBB))))) &&
+                  MLI.getLoopFor(&*prev(MachineFunction::iterator(&MBB))))) &&
              "Loop isn't contiguous");
     } else {
       // Assert that non-loops have no backedge predecessors.
@@ -257,7 +257,7 @@ static void PlaceMarkers(MachineFunction &MF, const MachineLoopInfo &MLI,
           Iter = next(MachineFunction::iterator(Bottom));
         }
         BuildMI(MBB, MBB.begin(), DebugLoc(), TII.get(WebAssembly::LOOP))
-            .addMBB(Iter);
+            .addMBB(&*Iter);
       }
 
     // Check for forward branches and switches that need BLOCKS placed.

--- a/lib/Target/X86/X86FrameLowering.cpp
+++ b/lib/Target/X86/X86FrameLowering.cpp
@@ -517,8 +517,7 @@ MachineInstr *X86FrameLowering::emitStackProbeInline(
   MachineBasicBlock *LoopMBB = MF.CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *ContinueMBB = MF.CreateMachineBasicBlock(LLVM_BB);
 
-  MachineFunction::iterator MBBIter = MBB;
-  ++MBBIter;
+  MachineFunction::iterator MBBIter = std::next(MBB.getIterator());
 
   MF.insert(MBBIter, RoundMBB);
   MF.insert(MBBIter, LoopMBB);

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -20497,8 +20497,7 @@ X86TargetLowering::EmitGCTransitionRA(MachineInstr *MI,
          "Invalid Pointer Size!");
 
   const BasicBlock *BB = MBB->getBasicBlock();
-  MachineFunction::iterator It = MBB;
-  ++It;
+  MachineFunction::iterator It = std::next(MBB->getIterator());
 
   // Operands to this pseudo-instruction:
   //
@@ -20609,8 +20608,7 @@ X86TargetLowering::EmitGCTransitionPause(MachineInstr *MI,
          "Invalid Pointer Size!");
 
   const BasicBlock *BB = MBB->getBasicBlock();
-  MachineFunction::iterator It = MBB;
-  ++It;
+  MachineFunction::iterator It = std::next(MBB->getIterator());
 
   // Operands to this pseudo-instruction:
   //

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -26,6 +26,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Analysis/LibCallSemantics.h"
 #include "llvm/CodeGen/IntrinsicLowering.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -477,13 +478,6 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
     setOperationAction(ISD::EH_LABEL, MVT::Other, Expand);
   }
 
-  if (Subtarget->isTarget64BitLP64()) {
-    setExceptionPointerRegister(X86::RAX);
-    setExceptionSelectorRegister(X86::RDX);
-  } else {
-    setExceptionPointerRegister(X86::EAX);
-    setExceptionSelectorRegister(X86::EDX);
-  }
   setOperationAction(ISD::FRAME_TO_ARGS_OFFSET, MVT::i32, Custom);
   setOperationAction(ISD::FRAME_TO_ARGS_OFFSET, MVT::i64, Custom);
 
@@ -7858,6 +7852,59 @@ static SDValue lowerVectorShuffleAsElementInsertion(
   return V2;
 }
 
+/// \brief Try to lower broadcast of a single - truncated - integer element,
+/// coming from a scalar_to_vector/build_vector node \p V0 with larger elements.
+///
+/// This assumes we have AVX2.
+static SDValue lowerVectorShuffleAsTruncBroadcast(SDLoc DL, MVT VT, SDValue V0,
+                                                  int BroadcastIdx,
+                                                  const X86Subtarget *Subtarget,
+                                                  SelectionDAG &DAG) {
+  assert(Subtarget->hasAVX2() &&
+         "We can only lower integer broadcasts with AVX2!");
+
+  EVT EltVT = VT.getVectorElementType();
+  EVT V0VT = V0.getValueType();
+
+  assert(VT.isInteger() && "Unexpected non-integer trunc broadcast!");
+  assert(V0VT.isVector() && "Unexpected non-vector vector-sized value!");
+
+  EVT V0EltVT = V0VT.getVectorElementType();
+  if (!V0EltVT.isInteger())
+    return SDValue();
+
+  const unsigned EltSize = EltVT.getSizeInBits();
+  const unsigned V0EltSize = V0EltVT.getSizeInBits();
+
+  // This is only a truncation if the original element type is larger.
+  if (V0EltSize <= EltSize)
+    return SDValue();
+
+  assert(((V0EltSize % EltSize) == 0) &&
+         "Scalar type sizes must all be powers of 2 on x86!");
+
+  const unsigned V0Opc = V0.getOpcode();
+  const unsigned Scale = V0EltSize / EltSize;
+  const unsigned V0BroadcastIdx = BroadcastIdx / Scale;
+
+  if ((V0Opc != ISD::SCALAR_TO_VECTOR || V0BroadcastIdx != 0) &&
+      V0Opc != ISD::BUILD_VECTOR)
+    return SDValue();
+
+  SDValue Scalar = V0.getOperand(V0BroadcastIdx);
+
+  // If we're extracting non-least-significant bits, shift so we can truncate.
+  // Hopefully, we can fold away the trunc/srl/load into the broadcast.
+  // Even if we can't (and !isShuffleFoldableLoad(Scalar)), prefer
+  // vpbroadcast+vmovd+shr to vpshufb(m)+vmovd.
+  if (const int OffsetIdx = BroadcastIdx % Scale)
+    Scalar = DAG.getNode(ISD::SRL, DL, Scalar.getValueType(), Scalar,
+            DAG.getConstant(OffsetIdx * EltSize, DL, Scalar.getValueType()));
+
+  return DAG.getNode(X86ISD::VBROADCAST, DL, VT,
+                     DAG.getNode(ISD::TRUNCATE, DL, EltVT, Scalar));
+}
+
 /// \brief Try to lower broadcast of a single element.
 ///
 /// For convenience, this code also bundles all of the subtarget feature set
@@ -7921,18 +7968,10 @@ static SDValue lowerVectorShuffleAsBroadcast(SDLoc DL, MVT VT, SDValue V,
   // First, look through bitcast: if the original value has a larger element
   // type than the shuffle, the broadcast element is in essence truncated.
   // Make that explicit to ease folding.
-  if (V.getOpcode() == ISD::BITCAST && VT.isInteger()) {
-    MVT EltVT = VT.getVectorElementType();
-    SDValue V0 = V.getOperand(0);
-    MVT V0VT = V0.getSimpleValueType();
-
-    if (V0VT.isInteger() && V0VT.getVectorElementType().bitsGT(EltVT) &&
-        ((V0.getOpcode() == ISD::BUILD_VECTOR ||
-         (V0.getOpcode() == ISD::SCALAR_TO_VECTOR && BroadcastIdx == 0)))) {
-      V = DAG.getNode(ISD::TRUNCATE, DL, EltVT, V0.getOperand(BroadcastIdx));
-      BroadcastIdx = 0;
-    }
-  }
+  if (V.getOpcode() == ISD::BITCAST && VT.isInteger())
+    if (SDValue TruncBroadcast = lowerVectorShuffleAsTruncBroadcast(
+            DL, VT, V.getOperand(0), BroadcastIdx, Subtarget, DAG))
+      return TruncBroadcast;
 
   // Also check the simpler case, where we can directly reuse the scalar.
   if (V.getOpcode() == ISD::BUILD_VECTOR ||
@@ -17196,6 +17235,21 @@ SDValue X86TargetLowering::LowerFRAME_TO_ARGS_OFFSET(SDValue Op,
                                                      SelectionDAG &DAG) const {
   const X86RegisterInfo *RegInfo = Subtarget->getRegisterInfo();
   return DAG.getIntPtrConstant(2 * RegInfo->getSlotSize(), SDLoc(Op));
+}
+
+unsigned X86TargetLowering::getExceptionPointerRegister(
+    const Constant *PersonalityFn) const {
+  if (classifyEHPersonality(PersonalityFn) == EHPersonality::CoreCLR)
+    return Subtarget->isTarget64BitLP64() ? X86::RDX : X86::EDX;
+
+  return Subtarget->isTarget64BitLP64() ? X86::RAX : X86::EAX;
+}
+
+unsigned X86TargetLowering::getExceptionSelectorRegister(
+    const Constant *PersonalityFn) const {
+  // Funclet personalities don't use selectors (the runtime does the selection).
+  assert(!isFuncletEHPersonality(classifyEHPersonality(PersonalityFn)));
+  return Subtarget->isTarget64BitLP64() ? X86::RDX : X86::EDX;
 }
 
 SDValue X86TargetLowering::LowerEH_RETURN(SDValue Op, SelectionDAG &DAG) const {

--- a/lib/Target/X86/X86ISelLowering.h
+++ b/lib/Target/X86/X86ISelLowering.h
@@ -889,6 +889,16 @@ namespace llvm {
     unsigned getRegisterByName(const char* RegName, EVT VT,
                                SelectionDAG &DAG) const override;
 
+    /// If a physical register, this returns the register that receives the
+    /// exception address on entry to an EH pad.
+    unsigned
+    getExceptionPointerRegister(const Constant *PersonalityFn) const override;
+
+    /// If a physical register, this returns the register that receives the
+    /// exception typeid on entry to a landing pad.
+    unsigned
+    getExceptionSelectorRegister(const Constant *PersonalityFn) const override;
+
     /// This method returns a target specific FastISel object,
     /// or null if the target does not support "fast" ISel.
     FastISel *createFastISel(FunctionLoweringInfo &funcInfo,

--- a/lib/Target/X86/X86InstrSSE.td
+++ b/lib/Target/X86/X86InstrSSE.td
@@ -8365,6 +8365,12 @@ let Predicates = [HasAVX2] in {
             (VPBROADCASTWrm addr:$src)>;
   def : Pat<(v16i16 (X86VBroadcast (i16 (trunc (i32 (load addr:$src)))))),
             (VPBROADCASTWYrm addr:$src)>;
+  def : Pat<(v8i16 (X86VBroadcast
+              (i16 (trunc (i32 (zextloadi16 addr:$src)))))),
+            (VPBROADCASTWrm addr:$src)>;
+  def : Pat<(v16i16 (X86VBroadcast
+              (i16 (trunc (i32 (zextloadi16 addr:$src)))))),
+            (VPBROADCASTWYrm addr:$src)>;
 
   // Provide aliases for broadcast from the same register class that
   // automatically does the extract.

--- a/lib/Target/XCore/XCoreFrameLowering.cpp
+++ b/lib/Target/XCore/XCoreFrameLowering.cpp
@@ -160,18 +160,18 @@ static void GetSpillList(SmallVectorImpl<StackSlotInfo> &SpillList,
 /// As offsets are negative, the largest offsets will be first.
 static void GetEHSpillList(SmallVectorImpl<StackSlotInfo> &SpillList,
                            MachineFrameInfo *MFI, XCoreFunctionInfo *XFI,
+                           const Constant *PersonalityFn,
                            const TargetLowering *TL) {
   assert(XFI->hasEHSpillSlot() && "There are no EH register spill slots");
-  const int* EHSlot = XFI->getEHSpillSlot();
-  SpillList.push_back(StackSlotInfo(EHSlot[0],
-                                    MFI->getObjectOffset(EHSlot[0]),
-                                    TL->getExceptionPointerRegister()));
-  SpillList.push_back(StackSlotInfo(EHSlot[0],
-                                    MFI->getObjectOffset(EHSlot[1]),
-                                    TL->getExceptionSelectorRegister()));
+  const int *EHSlot = XFI->getEHSpillSlot();
+  SpillList.push_back(
+      StackSlotInfo(EHSlot[0], MFI->getObjectOffset(EHSlot[0]),
+                    TL->getExceptionPointerRegister(PersonalityFn)));
+  SpillList.push_back(
+      StackSlotInfo(EHSlot[0], MFI->getObjectOffset(EHSlot[1]),
+                    TL->getExceptionSelectorRegister(PersonalityFn)));
   std::sort(SpillList.begin(), SpillList.end(), CompareSSIOffset);
 }
-
 
 static MachineMemOperand *
 getFrameIndexMMO(MachineBasicBlock &MBB, int FrameIndex, unsigned flags) {
@@ -322,8 +322,11 @@ void XCoreFrameLowering::emitPrologue(MachineFunction &MF,
     if (XFI->hasEHSpillSlot()) {
       // The unwinder requires stack slot & CFI offsets for the exception info.
       // We do not save/spill these registers.
-      SmallVector<StackSlotInfo,2> SpillList;
-      GetEHSpillList(SpillList, MFI, XFI,
+      const Function *Fn = MF.getFunction();
+      const Constant *PersonalityFn =
+          Fn->hasPersonalityFn() ? Fn->getPersonalityFn() : nullptr;
+      SmallVector<StackSlotInfo, 2> SpillList;
+      GetEHSpillList(SpillList, MFI, XFI, PersonalityFn,
                      MF.getSubtarget().getTargetLowering());
       assert(SpillList.size()==2 && "Unexpected SpillList size");
       EmitCfiOffset(MBB, MBBI, dl, TII, MMI,
@@ -354,8 +357,12 @@ void XCoreFrameLowering::emitEpilogue(MachineFunction &MF,
   if (RetOpcode == XCore::EH_RETURN) {
     // 'Restore' the exception info the unwinder has placed into the stack
     // slots.
-    SmallVector<StackSlotInfo,2> SpillList;
-    GetEHSpillList(SpillList, MFI, XFI, MF.getSubtarget().getTargetLowering());
+    const Function *Fn = MF.getFunction();
+    const Constant *PersonalityFn =
+        Fn->hasPersonalityFn() ? Fn->getPersonalityFn() : nullptr;
+    SmallVector<StackSlotInfo, 2> SpillList;
+    GetEHSpillList(SpillList, MFI, XFI, PersonalityFn,
+                   MF.getSubtarget().getTargetLowering());
     RestoreSpillList(MBB, MBBI, dl, TII, RemainingAdj, SpillList);
 
     // Return to the landing pad.

--- a/lib/Target/XCore/XCoreISelLowering.cpp
+++ b/lib/Target/XCore/XCoreISelLowering.cpp
@@ -151,8 +151,6 @@ XCoreTargetLowering::XCoreTargetLowering(const TargetMachine &TM,
 
   // Exception handling
   setOperationAction(ISD::EH_RETURN, MVT::Other, Custom);
-  setExceptionPointerRegister(XCore::R0);
-  setExceptionSelectorRegister(XCore::R1);
   setOperationAction(ISD::FRAME_TO_ARGS_OFFSET, MVT::i32, Custom);
 
   // Atomic operations

--- a/lib/Target/XCore/XCoreISelLowering.h
+++ b/lib/Target/XCore/XCoreISelLowering.h
@@ -125,6 +125,20 @@ namespace llvm {
     bool isLegalAddressingMode(const DataLayout &DL, const AddrMode &AM,
                                Type *Ty, unsigned AS) const override;
 
+    /// If a physical register, this returns the register that receives the
+    /// exception address on entry to an EH pad.
+    unsigned
+    getExceptionPointerRegister(const Constant *PersonalityFn) const override {
+      return XCore::R0;
+    }
+
+    /// If a physical register, this returns the register that receives the
+    /// exception typeid on entry to a landing pad.
+    unsigned
+    getExceptionSelectorRegister(const Constant *PersonalityFn) const override {
+      return XCore::R1;
+    }
+
   private:
     const TargetMachine &TM;
     const XCoreSubtarget &Subtarget;

--- a/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -401,6 +401,12 @@ Instruction *InstCombiner::FoldPHIArgLoadIntoPHI(PHINode &PN) {
 /// require special-casing a cast from the 'i1' type. See the comment in
 /// FoldPHIArgOpIntoPHI() about pessimizing illegal integer types.
 Instruction *InstCombiner::FoldPHIArgZextsIntoPHI(PHINode &Phi) {
+  // We cannot create a new instruction after the PHI if the terminator is an
+  // EHPad because there is no valid insertion point.
+  if (TerminatorInst *TI = Phi.getParent()->getTerminator())
+    if (TI->isEHPad())
+      return nullptr;
+
   // Early exit for the common case of a phi with two operands. These are
   // handled elsewhere. See the comment below where we check the count of zexts
   // and constants for more details.
@@ -469,6 +475,12 @@ Instruction *InstCombiner::FoldPHIArgZextsIntoPHI(PHINode &Phi) {
 /// only used by the PHI, PHI together their inputs, and do the operation once,
 /// to the result of the PHI.
 Instruction *InstCombiner::FoldPHIArgOpIntoPHI(PHINode &PN) {
+  // We cannot create a new instruction after the PHI if the terminator is an
+  // EHPad because there is no valid insertion point.
+  if (TerminatorInst *TI = PN.getParent()->getTerminator())
+    if (TI->isEHPad())
+      return nullptr;
+
   Instruction *FirstInst = cast<Instruction>(PN.getIncomingValue(0));
 
   if (isa<GetElementPtrInst>(FirstInst))

--- a/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -3012,7 +3012,7 @@ static bool prepareICWorklistFromFunction(Function &F, const DataLayout &DL,
     while (EndInst != BB->begin()) {
       // Delete the next to last instruction.
       Instruction *Inst = &*--EndInst->getIterator();
-      if (!Inst->use_empty())
+      if (!Inst->use_empty() && !Inst->getType()->isTokenTy())
         Inst->replaceAllUsesWith(UndefValue::get(Inst->getType()));
       if (Inst->isEHPad()) {
         EndInst = Inst;
@@ -3022,7 +3022,8 @@ static bool prepareICWorklistFromFunction(Function &F, const DataLayout &DL,
         ++NumDeadInst;
         MadeIRChange = true;
       }
-      Inst->eraseFromParent();
+      if (!Inst->getType()->isTokenTy())
+        Inst->eraseFromParent();
     }
   }
 

--- a/lib/Transforms/Scalar/LoopLoadElimination.cpp
+++ b/lib/Transforms/Scalar/LoopLoadElimination.cpp
@@ -373,7 +373,7 @@ public:
     Value *Initial =
         new LoadInst(InitialPtr, "load_initial", PH->getTerminator());
     PHINode *PHI = PHINode::Create(Initial->getType(), 2, "store_forwarded",
-                                   L->getHeader()->begin());
+                                   &L->getHeader()->front());
     PHI->addIncoming(Initial, PH);
     PHI->addIncoming(Cand.Store->getOperand(0), L->getLoopLatch());
 

--- a/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -304,7 +304,9 @@ bool TailCallElim::markTails(Function &F, bool &AllCallsAreTailCalls) {
       if (!CI || CI->isTailCall())
         continue;
 
-      if (CI->doesNotAccessMemory()) {
+      bool IsNoTail = CI->isNoTailCall();
+
+      if (!IsNoTail && CI->doesNotAccessMemory()) {
         // A call to a readnone function whose arguments are all things computed
         // outside this function can be marked tail. Even if you stored the
         // alloca address into a global, a readnone function can't load the
@@ -332,7 +334,7 @@ bool TailCallElim::markTails(Function &F, bool &AllCallsAreTailCalls) {
         }
       }
 
-      if (Escaped == UNESCAPED && !Tracker.AllocaUsers.count(CI)) {
+      if (!IsNoTail && Escaped == UNESCAPED && !Tracker.AllocaUsers.count(CI)) {
         DeferredTails.push_back(CI);
       } else {
         AllCallsAreTailCalls = false;

--- a/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -1093,7 +1093,8 @@ Value *LibCallSimplifier::optimizePow(CallInst *CI, IRBuilder<> &B) {
     if (Op1C->isExactlyValue(2.0) &&
         hasUnaryFloatFn(TLI, Op1->getType(), LibFunc::exp2, LibFunc::exp2f,
                         LibFunc::exp2l))
-      return EmitUnaryFloatFnCall(Op2, "exp2", B, Callee->getAttributes());
+      return EmitUnaryFloatFnCall(Op2, TLI->getName(LibFunc::exp2), B,
+                                  Callee->getAttributes());
     // pow(10.0, x) -> exp10(x)
     if (Op1C->isExactlyValue(10.0) &&
         hasUnaryFloatFn(TLI, Op1->getType(), LibFunc::exp10, LibFunc::exp10f,

--- a/test/Bitcode/compatibility.ll
+++ b/test/Bitcode/compatibility.ll
@@ -1144,6 +1144,13 @@ define void @instructions.call_musttail(i8* inalloca %val) {
   ret void
 }
 
+define void @instructions.call_notail() {
+  notail call void @f1()
+  ; CHECK: notail call void @f1()
+
+  ret void
+}
+
 define void @instructions.landingpad() personality i32 -2 {
   invoke void @llvm.donothing() to label %proceed unwind label %catch1
   invoke void @llvm.donothing() to label %proceed unwind label %catch2

--- a/test/CodeGen/AArch64/fast-isel-cmp-vec.ll
+++ b/test/CodeGen/AArch64/fast-isel-cmp-vec.ll
@@ -1,0 +1,100 @@
+; RUN: llc -mtriple=aarch64-apple-darwin -fast-isel -verify-machineinstrs \
+; RUN:   -aarch64-atomic-cfg-tidy=0 -disable-cgp -disable-branch-fold \
+; RUN:   < %s | FileCheck %s
+
+;
+; Verify that we don't mess up vector comparisons in fast-isel.
+;
+
+define <2 x i32> @icmp_v2i32(<2 x i32> %a) {
+; CHECK-LABEL: icmp_v2i32:
+; CHECK:      ; BB#0:
+; CHECK-NEXT:  cmeq.2s [[CMP:v[0-9]+]], v0, #0
+; CHECK-NEXT: ; BB#1:
+; CHECK-NEXT:  movi.2s [[MASK:v[0-9]+]], #0x1
+; CHECK-NEXT:  and.8b v0, [[CMP]], [[MASK]]
+; CHECK-NEXT:  ret
+  %c = icmp eq <2 x i32> %a, zeroinitializer
+  br label %bb2
+bb2:
+  %z = zext <2 x i1> %c to <2 x i32>
+  ret <2 x i32> %z
+}
+
+define <2 x i32> @icmp_constfold_v2i32(<2 x i32> %a) {
+; CHECK-LABEL: icmp_constfold_v2i32:
+; CHECK:      ; BB#0:
+; CHECK-NEXT:  movi d[[CMP:[0-9]+]], #0xffffffffffffffff
+; CHECK-NEXT: ; BB#1:
+; CHECK-NEXT:  movi.2s [[MASK:v[0-9]+]], #0x1
+; CHECK-NEXT:  and.8b v0, v[[CMP]], [[MASK]]
+; CHECK-NEXT:  ret
+  %1 = icmp eq <2 x i32> %a, %a
+  br label %bb2
+bb2:
+  %2 = zext <2 x i1> %1 to <2 x i32>
+  ret <2 x i32> %2
+}
+
+define <4 x i32> @icmp_v4i32(<4 x i32> %a) {
+; CHECK-LABEL: icmp_v4i32:
+; CHECK:      ; BB#0:
+; CHECK-NEXT:  cmeq.4s [[CMP:v[0-9]+]], v0, #0
+; CHECK-NEXT:  xtn.4h [[CMPV4I16:v[0-9]+]], [[CMP]]
+; CHECK-NEXT: ; BB#1:
+; CHECK-NEXT:  movi.4h [[MASK:v[0-9]+]], #0x1
+; CHECK-NEXT:  and.8b [[ZEXT:v[0-9]+]], [[CMPV4I16]], [[MASK]]
+; CHECK-NEXT:  ushll.4s v0, [[ZEXT]], #0
+; CHECK-NEXT:  ret
+  %c = icmp eq <4 x i32> %a, zeroinitializer
+  br label %bb2
+bb2:
+  %z = zext <4 x i1> %c to <4 x i32>
+  ret <4 x i32> %z
+}
+
+define <4 x i32> @icmp_constfold_v4i32(<4 x i32> %a) {
+; CHECK-LABEL: icmp_constfold_v4i32:
+; CHECK:      ; BB#0:
+; CHECK-NEXT:  movi d[[CMP:[0-9]+]], #0xffffffffffffffff
+; CHECK-NEXT: ; BB#1:
+; CHECK-NEXT:  movi.4h [[MASK:v[0-9]+]], #0x1
+; CHECK-NEXT:  and.8b [[ZEXT:v[0-9]+]], v[[CMP]], [[MASK]]
+; CHECK-NEXT:  ushll.4s v0, [[ZEXT]], #0
+; CHECK-NEXT:  ret
+  %1 = icmp eq <4 x i32> %a, %a
+  br label %bb2
+bb2:
+  %2 = zext <4 x i1> %1 to <4 x i32>
+  ret <4 x i32> %2
+}
+
+define <16 x i8> @icmp_v16i8(<16 x i8> %a) {
+; CHECK-LABEL: icmp_v16i8:
+; CHECK:      ; BB#0:
+; CHECK-NEXT:  cmeq.16b [[CMP:v[0-9]+]], v0, #0
+; CHECK-NEXT: ; BB#1:
+; CHECK-NEXT:  movi.16b [[MASK:v[0-9]+]], #0x1
+; CHECK-NEXT:  and.16b v0, [[CMP]], [[MASK]]
+; CHECK-NEXT:  ret
+  %c = icmp eq <16 x i8> %a, zeroinitializer
+  br label %bb2
+bb2:
+  %z = zext <16 x i1> %c to <16 x i8>
+  ret <16 x i8> %z
+}
+
+define <16 x i8> @icmp_constfold_v16i8(<16 x i8> %a) {
+; CHECK-LABEL: icmp_constfold_v16i8:
+; CHECK:      ; BB#0:
+; CHECK-NEXT:  movi.2d [[CMP:v[0-9]+]], #0xffffffffffffffff
+; CHECK-NEXT: ; BB#1:
+; CHECK-NEXT:  movi.16b [[MASK:v[0-9]+]], #0x1
+; CHECK-NEXT:  and.16b v0, [[CMP]], [[MASK]]
+; CHECK-NEXT:  ret
+  %1 = icmp eq <16 x i8> %a, %a
+  br label %bb2
+bb2:
+  %2 = zext <16 x i1> %1 to <16 x i8>
+  ret <16 x i8> %2
+}

--- a/test/CodeGen/AMDGPU/kernel-args.ll
+++ b/test/CodeGen/AMDGPU/kernel-args.ll
@@ -4,8 +4,10 @@
 ; RUN: llc < %s -march=r600 -mcpu=cayman | FileCheck %s --check-prefix=EG --check-prefix=FUNC
 
 ; FUNC-LABEL: {{^}}i8_arg:
-; EG: MOV {{[ *]*}}T{{[0-9]+\.[XYZW]}}, KC0[2].Z
-; GCN: buffer_load_ubyte
+; EG: AND_INT {{[ *]*}}T{{[0-9]+\.[XYZW]}}, KC0[2].Z
+; SI: s_load_dword [[VAL:s[0-9]+]], s[{{[0-9]+:[0-9]+}}], 0xb
+; VI: s_load_dword [[VAL:s[0-9]+]], s[{{[0-9]+:[0-9]+}}], 0x2c
+; GCN: s_and_b32 s{{[0-9]+}}, [[VAL]], 0xff
 
 define void @i8_arg(i32 addrspace(1)* nocapture %out, i8 %in) nounwind {
 entry:
@@ -39,8 +41,10 @@ entry:
 }
 
 ; FUNC-LABEL: {{^}}i16_arg:
-; EG: MOV {{[ *]*}}T{{[0-9]+\.[XYZW]}}, KC0[2].Z
-; GCN: buffer_load_ushort
+; EG: AND_INT {{[ *]*}}T{{[0-9]+\.[XYZW]}}, KC0[2].Z
+; SI: s_load_dword [[VAL:s[0-9]+]], s[{{[0-9]+:[0-9]+}}], 0xb
+; VI: s_load_dword [[VAL:s[0-9]+]], s[{{[0-9]+:[0-9]+}}], 0x2c
+; GCN: s_and_b32 s{{[0-9]+}}, [[VAL]], 0xff
 
 define void @i16_arg(i32 addrspace(1)* nocapture %out, i16 %in) nounwind {
 entry:

--- a/test/CodeGen/AMDGPU/no-shrink-extloads.ll
+++ b/test/CodeGen/AMDGPU/no-shrink-extloads.ll
@@ -189,3 +189,15 @@ define void @truncate_buffer_load_i64_to_i8(i8 addrspace(1)* %out, i64 addrspace
   store i8 %trunc, i8 addrspace(1)* %gep.out
   ret void
 }
+
+; FUNC-LABEL: {{^}}smrd_mask_i32_to_i16
+; SI: s_load_dword [[LOAD:s[0-9]+]], s[{{[0-9]+}}:{{[0-9]+}}], 0x0
+; SI: s_waitcnt lgkmcnt(0)
+; SI: s_and_b32 s{{[0-9]+}}, [[LOAD]], 0xffff
+define void @smrd_mask_i32_to_i16(i32 addrspace(1)* %out, i32 addrspace(2)* %in) {
+entry:
+  %val = load i32, i32 addrspace(2)* %in
+  %mask = and i32 %val, 65535
+  store i32 %mask, i32 addrspace(1)* %out
+  ret void
+}

--- a/test/CodeGen/AMDGPU/setcc-opt.ll
+++ b/test/CodeGen/AMDGPU/setcc-opt.ll
@@ -142,9 +142,12 @@ define void @sext_bool_icmp_ne_k(i1 addrspace(1)* %out, i32 %a, i32 %b) nounwind
 }
 
 ; FUNC-LABEL: {{^}}cmp_zext_k_i8max:
-; GCN: buffer_load_ubyte [[B:v[0-9]+]], s{{\[[0-9]+:[0-9]+\]}}, 0 offset:44
-; GCN: v_mov_b32_e32 [[K255:v[0-9]+]], 0xff{{$}}
-; GCN: v_cmp_ne_i32_e32 vcc, [[K255]], [[B]]
+; SI: s_load_dword [[VALUE:s[0-9]+]], s{{\[[0-9]+:[0-9]+\]}}, 0xb
+; VI: s_load_dword [[VALUE:s[0-9]+]], s{{\[[0-9]+:[0-9]+\]}}, 0x2c
+; GCN: s_movk_i32 [[K255:s[0-9]+]], 0xff
+; GCN: s_and_b32 [[B:s[0-9]+]], [[VALUE]], [[K255]]
+; GCN: v_mov_b32_e32 [[VK255:v[0-9]+]], [[K255]]
+; GCN: v_cmp_ne_i32_e32 vcc, [[B]], [[VK255]]
 ; GCN-NEXT: v_cndmask_b32_e64 [[RESULT:v[0-9]+]], 0, 1, vcc
 ; GCN: buffer_store_byte [[RESULT]]
 ; GCN: s_endpgm
@@ -187,9 +190,12 @@ define void @cmp_sext_k_neg1_i8_sext_arg(i1 addrspace(1)* %out, i8 signext %b) n
 ; Should do a buffer_load_sbyte and compare with -1
 
 ; FUNC-LABEL: {{^}}cmp_sext_k_neg1_i8_arg:
-; GCN-DAG: buffer_load_ubyte [[B:v[0-9]+]]
-; GCN-DAG: v_mov_b32_e32 [[K:v[0-9]+]], 0xff{{$}}
-; GCN: v_cmp_ne_i32_e32 vcc, [[K]], [[B]]{{$}}
+; SI: s_load_dword [[VAL:s[0-9]+]], s[{{[0-9]+:[0-9]+}}], 0xb
+; VI: s_load_dword [[VAL:s[0-9]+]], s{{\[[0-9]+:[0-9]+\]}}, 0x2c
+; GCN: s_movk_i32 [[K:s[0-9]+]], 0xff
+; GCN: s_and_b32 [[B:s[0-9]+]], [[VAL]], [[K]]
+; GCN: v_mov_b32_e32 [[VK:v[0-9]+]], [[K]]
+; GCN: v_cmp_ne_i32_e32 vcc, [[B]], [[VK]]{{$}}
 ; GCN-NEXT: v_cndmask_b32_e64 [[RESULT:v[0-9]+]], 0, 1, vcc
 ; GCN: buffer_store_byte [[RESULT]]
 ; GCN: s_endpgm

--- a/test/CodeGen/WebAssembly/call.ll
+++ b/test/CodeGen/WebAssembly/call.ll
@@ -69,7 +69,7 @@ define void @call_void_nullary() {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result i32
 ; CHECK-NEXT: .local i32, i32
-; CHECK-NEXT: get_local 0
+; CHECK-NEXT: get_local push, 0
 ; CHECK-NEXT: set_local 1, pop
 ; CHECK-NEXT: call $i32_unary, push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop
@@ -84,9 +84,9 @@ define i32 @call_i32_unary(i32 %a) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result i32
 ; CHECK-NEXT: .local i32, i32, i32
-; CHECK-NEXT: get_local 1
+; CHECK-NEXT: get_local push, 1
 ; CHECK-NEXT: set_local 2, pop
-; CHECK-NEXT: get_local 0
+; CHECK-NEXT: get_local push, 0
 ; CHECK-NEXT: set_local 3, pop
 ; CHECK-NEXT: call $i32_binary, push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop
@@ -99,7 +99,7 @@ define i32 @call_i32_binary(i32 %a, i32 %b) {
 ; CHECK-LABEL: call_indirect_void:
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .local i32
-; CHECK-NEXT: get_local 0
+; CHECK-NEXT: get_local push, 0
 ; CHECK-NEXT: set_local 1, pop
 ; CHECK-NEXT: call_indirect (get_local 1){{$}}
 ; CHECK-NEXT: return
@@ -112,7 +112,7 @@ define void @call_indirect_void(void ()* %callee) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result i32
 ; CHECK-NEXT: .local i32, i32
-; CHECK-NEXT: get_local 0
+; CHECK-NEXT: get_local push, 0
 ; CHECK-NEXT: set_local 1, pop
 ; CHECK-NEXT: call_indirect (get_local 1), push{{$}}
 ; CHECK-NEXT: set_local 2, pop

--- a/test/CodeGen/WebAssembly/cfg-stackify.ll
+++ b/test/CodeGen/WebAssembly/cfg-stackify.ll
@@ -11,7 +11,7 @@ declare void @something()
 
 ; CHECK-LABEL: test0:
 ; CHECK: loop
-; CHECK: add
+; CHECK: i32.add
 ; CHECK: br_if
 ; CHECK: call
 ; CHECK: br $BB0_1{{$}}
@@ -39,7 +39,7 @@ back:
 
 ; CHECK-LABEL: test1:
 ; CHECK: loop
-; CHECK: add
+; CHECK: i32.add
 ; CHECK: br_if
 ; CHECK: call
 ; CHECK: br $BB1_1{{$}}

--- a/test/CodeGen/WebAssembly/comparisons_f32.ll
+++ b/test/CodeGen/WebAssembly/comparisons_f32.ll
@@ -11,15 +11,15 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param f32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f32, f32, i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 3){{$}}
+; CHECK-NEXT: f32.eq push, (get_local 3), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 2), (get_local 2){{$}}
+; CHECK-NEXT: f32.eq push, (get_local 2), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
-; CHECK-NEXT: and push, (get_local 5), (get_local 4){{$}}
+; CHECK-NEXT: i32.and push, (get_local 5), (get_local 4){{$}}
 ; CHECK-NEXT: set_local 6, pop{{$}}
 ; CHECK-NEXT: return (get_local 6){{$}}
 define i32 @ord_f32(float %x, float %y) {
@@ -33,15 +33,15 @@ define i32 @ord_f32(float %x, float %y) {
 ; CHECK-NEXT: .param f32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f32, f32, i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 3), (get_local 3){{$}}
+; CHECK-NEXT: f32.ne push, (get_local 3), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 2), (get_local 2){{$}}
+; CHECK-NEXT: f32.ne push, (get_local 2), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
-; CHECK-NEXT: or push, (get_local 5), (get_local 4){{$}}
+; CHECK-NEXT: i32.or push, (get_local 5), (get_local 4){{$}}
 ; CHECK-NEXT: set_local 6, pop{{$}}
 ; CHECK-NEXT: return (get_local 6){{$}}
 define i32 @uno_f32(float %x, float %y) {
@@ -55,11 +55,11 @@ define i32 @uno_f32(float %x, float %y) {
 ; CHECK-NEXT: .param f32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f32, f32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: f32.eq push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @oeq_f32(float %x, float %y) {
@@ -69,7 +69,7 @@ define i32 @oeq_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: une_f32:
-; CHECK: ne push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.ne push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @une_f32(float %x, float %y) {
   %a = fcmp une float %x, %y
@@ -78,7 +78,7 @@ define i32 @une_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: olt_f32:
-; CHECK: lt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.lt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @olt_f32(float %x, float %y) {
   %a = fcmp olt float %x, %y
@@ -87,7 +87,7 @@ define i32 @olt_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: ole_f32:
-; CHECK: le push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.le push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ole_f32(float %x, float %y) {
   %a = fcmp ole float %x, %y
@@ -96,7 +96,7 @@ define i32 @ole_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: ogt_f32:
-; CHECK: gt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.gt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ogt_f32(float %x, float %y) {
   %a = fcmp ogt float %x, %y
@@ -105,7 +105,7 @@ define i32 @ogt_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: oge_f32:
-; CHECK: ge push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.ge push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @oge_f32(float %x, float %y) {
   %a = fcmp oge float %x, %y
@@ -120,19 +120,19 @@ define i32 @oge_f32(float %x, float %y) {
 ; CHECK-NEXT: .param f32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f32, f32, i32, i32, i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: f32.eq push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 2), (get_local 2){{$}}
+; CHECK-NEXT: f32.ne push, (get_local 2), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 3), (get_local 3){{$}}
+; CHECK-NEXT: f32.ne push, (get_local 3), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 6, pop{{$}}
-; CHECK-NEXT: or push, (get_local 6), (get_local 5){{$}}
+; CHECK-NEXT: i32.or push, (get_local 6), (get_local 5){{$}}
 ; CHECK-NEXT: set_local 7, pop{{$}}
-; CHECK-NEXT: or push, (get_local 4), (get_local 7){{$}}
+; CHECK-NEXT: i32.or push, (get_local 4), (get_local 7){{$}}
 ; CHECK-NEXT: set_local 8, pop{{$}}
 ; CHECK-NEXT: return (get_local 8){{$}}
 define i32 @ueq_f32(float %x, float %y) {
@@ -142,7 +142,7 @@ define i32 @ueq_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: one_f32:
-; CHECK: ne push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.ne push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @one_f32(float %x, float %y) {
   %a = fcmp one float %x, %y
@@ -151,7 +151,7 @@ define i32 @one_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: ult_f32:
-; CHECK: lt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.lt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ult_f32(float %x, float %y) {
   %a = fcmp ult float %x, %y
@@ -160,7 +160,7 @@ define i32 @ult_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: ule_f32:
-; CHECK: le push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.le push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ule_f32(float %x, float %y) {
   %a = fcmp ule float %x, %y
@@ -169,7 +169,7 @@ define i32 @ule_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: ugt_f32:
-; CHECK: gt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.gt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ugt_f32(float %x, float %y) {
   %a = fcmp ugt float %x, %y
@@ -178,7 +178,7 @@ define i32 @ugt_f32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: uge_f32:
-; CHECK: ge push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.ge push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @uge_f32(float %x, float %y) {
   %a = fcmp uge float %x, %y

--- a/test/CodeGen/WebAssembly/comparisons_f64.ll
+++ b/test/CodeGen/WebAssembly/comparisons_f64.ll
@@ -11,15 +11,15 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param f64{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f64, f64, i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 3){{$}}
+; CHECK-NEXT: f64.eq push, (get_local 3), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 2), (get_local 2){{$}}
+; CHECK-NEXT: f64.eq push, (get_local 2), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
-; CHECK-NEXT: and push, (get_local 5), (get_local 4){{$}}
+; CHECK-NEXT: i32.and push, (get_local 5), (get_local 4){{$}}
 ; CHECK-NEXT: set_local 6, pop{{$}}
 ; CHECK-NEXT: return (get_local 6){{$}}
 define i32 @ord_f64(double %x, double %y) {
@@ -33,15 +33,15 @@ define i32 @ord_f64(double %x, double %y) {
 ; CHECK-NEXT: .param f64{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f64, f64, i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 3), (get_local 3){{$}}
+; CHECK-NEXT: f64.ne push, (get_local 3), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 2), (get_local 2){{$}}
+; CHECK-NEXT: f64.ne push, (get_local 2), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
-; CHECK-NEXT: or push, (get_local 5), (get_local 4){{$}}
+; CHECK-NEXT: i32.or push, (get_local 5), (get_local 4){{$}}
 ; CHECK-NEXT: set_local 6, pop{{$}}
 ; CHECK-NEXT: return (get_local 6){{$}}
 define i32 @uno_f64(double %x, double %y) {
@@ -55,11 +55,11 @@ define i32 @uno_f64(double %x, double %y) {
 ; CHECK-NEXT: .param f64{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f64, f64, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: f64.eq push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @oeq_f64(double %x, double %y) {
@@ -69,7 +69,7 @@ define i32 @oeq_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: une_f64:
-; CHECK: ne push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.ne push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @une_f64(double %x, double %y) {
   %a = fcmp une double %x, %y
@@ -78,7 +78,7 @@ define i32 @une_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: olt_f64:
-; CHECK: lt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.lt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @olt_f64(double %x, double %y) {
   %a = fcmp olt double %x, %y
@@ -87,7 +87,7 @@ define i32 @olt_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: ole_f64:
-; CHECK: le push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.le push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ole_f64(double %x, double %y) {
   %a = fcmp ole double %x, %y
@@ -96,7 +96,7 @@ define i32 @ole_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: ogt_f64:
-; CHECK: gt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.gt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ogt_f64(double %x, double %y) {
   %a = fcmp ogt double %x, %y
@@ -105,7 +105,7 @@ define i32 @ogt_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: oge_f64:
-; CHECK: ge push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.ge push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @oge_f64(double %x, double %y) {
   %a = fcmp oge double %x, %y
@@ -120,19 +120,19 @@ define i32 @oge_f64(double %x, double %y) {
 ; CHECK-NEXT: .param f64{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local f64, f64, i32, i32, i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: f64.eq push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 2), (get_local 2){{$}}
+; CHECK-NEXT: f64.ne push, (get_local 2), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
-; CHECK-NEXT: ne push, (get_local 3), (get_local 3){{$}}
+; CHECK-NEXT: f64.ne push, (get_local 3), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 6, pop{{$}}
-; CHECK-NEXT: or push, (get_local 6), (get_local 5){{$}}
+; CHECK-NEXT: i32.or push, (get_local 6), (get_local 5){{$}}
 ; CHECK-NEXT: set_local 7, pop{{$}}
-; CHECK-NEXT: or push, (get_local 4), (get_local 7){{$}}
+; CHECK-NEXT: i32.or push, (get_local 4), (get_local 7){{$}}
 ; CHECK-NEXT: set_local 8, pop{{$}}
 ; CHECK-NEXT: return (get_local 8){{$}}
 define i32 @ueq_f64(double %x, double %y) {
@@ -142,7 +142,7 @@ define i32 @ueq_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: one_f64:
-; CHECK: ne push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.ne push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @one_f64(double %x, double %y) {
   %a = fcmp one double %x, %y
@@ -151,7 +151,7 @@ define i32 @one_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: ult_f64:
-; CHECK: lt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.lt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ult_f64(double %x, double %y) {
   %a = fcmp ult double %x, %y
@@ -160,7 +160,7 @@ define i32 @ult_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: ule_f64:
-; CHECK: le push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.le push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ule_f64(double %x, double %y) {
   %a = fcmp ule double %x, %y
@@ -169,7 +169,7 @@ define i32 @ule_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: ugt_f64:
-; CHECK: gt push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.gt push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ugt_f64(double %x, double %y) {
   %a = fcmp ugt double %x, %y
@@ -178,7 +178,7 @@ define i32 @ugt_f64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: uge_f64:
-; CHECK: ge push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.ge push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @uge_f64(double %x, double %y) {
   %a = fcmp uge double %x, %y

--- a/test/CodeGen/WebAssembly/comparisons_i32.ll
+++ b/test/CodeGen/WebAssembly/comparisons_i32.ll
@@ -10,11 +10,11 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.eq push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @eq_i32(i32 %x, i32 %y) {
@@ -24,7 +24,7 @@ define i32 @eq_i32(i32 %x, i32 %y) {
 }
 
 ; CHECK-LABEL: ne_i32:
-; CHECK: ne push, (get_local 3), (get_local 2){{$}}
+; CHECK: i32.ne push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ne_i32(i32 %x, i32 %y) {
   %a = icmp ne i32 %x, %y

--- a/test/CodeGen/WebAssembly/comparisons_i64.ll
+++ b/test/CodeGen/WebAssembly/comparisons_i64.ll
@@ -10,11 +10,11 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i64, i64, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: eq push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.eq push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @eq_i64(i64 %x, i64 %y) {
@@ -24,7 +24,7 @@ define i32 @eq_i64(i64 %x, i64 %y) {
 }
 
 ; CHECK-LABEL: ne_i64:
-; CHECK: ne push, (get_local 3), (get_local 2){{$}}
+; CHECK: i64.ne push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define i32 @ne_i64(i64 %x, i64 %y) {
   %a = icmp ne i64 %x, %y

--- a/test/CodeGen/WebAssembly/conv.ll
+++ b/test/CodeGen/WebAssembly/conv.ll
@@ -9,7 +9,7 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i64, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i32.wrap/i64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -23,7 +23,7 @@ define i32 @i32_wrap_i64(i64 %x) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result i64
 ; CHECK-NEXT: .local i32, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i64.extend_s/i32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -37,7 +37,7 @@ define i64 @i64_extend_s_i32(i32 %x) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result i64
 ; CHECK-NEXT: .local i32, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i64.extend_u/i32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -51,7 +51,7 @@ define i64 @i64_extend_u_i32(i32 %x) {
 ; CHECK-NEXT: .param f32
 ; CHECK-NEXT: .result i32
 ; CHECK-NEXT: .local f32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i32.trunc_s/f32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -65,7 +65,7 @@ define i32 @i32_trunc_s_f32(float %x) {
 ; CHECK-NEXT: .param f32
 ; CHECK-NEXT: .result i32
 ; CHECK-NEXT: .local f32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i32.trunc_u/f32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -79,7 +79,7 @@ define i32 @i32_trunc_u_f32(float %x) {
 ; CHECK-NEXT: .param f64
 ; CHECK-NEXT: .result i32
 ; CHECK-NEXT: .local f64, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i32.trunc_s/f64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -93,7 +93,7 @@ define i32 @i32_trunc_s_f64(double %x) {
 ; CHECK-NEXT: .param f64
 ; CHECK-NEXT: .result i32
 ; CHECK-NEXT: .local f64, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i32.trunc_u/f64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -107,7 +107,7 @@ define i32 @i32_trunc_u_f64(double %x) {
 ; CHECK-NEXT: .param f32
 ; CHECK-NEXT: .result i64
 ; CHECK-NEXT: .local f32, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i64.trunc_s/f32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -121,7 +121,7 @@ define i64 @i64_trunc_s_f32(float %x) {
 ; CHECK-NEXT: .param f32
 ; CHECK-NEXT: .result i64
 ; CHECK-NEXT: .local f32, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i64.trunc_u/f32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -135,7 +135,7 @@ define i64 @i64_trunc_u_f32(float %x) {
 ; CHECK-NEXT: .param f64
 ; CHECK-NEXT: .result i64
 ; CHECK-NEXT: .local f64, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i64.trunc_s/f64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -149,7 +149,7 @@ define i64 @i64_trunc_s_f64(double %x) {
 ; CHECK-NEXT: .param f64
 ; CHECK-NEXT: .result i64
 ; CHECK-NEXT: .local f64, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i64.trunc_u/f64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -163,7 +163,7 @@ define i64 @i64_trunc_u_f64(double %x) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result f32
 ; CHECK-NEXT: .local i32, f32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f32.convert_s/i32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -177,7 +177,7 @@ define float @f32_convert_s_i32(i32 %x) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result f32
 ; CHECK-NEXT: .local i32, f32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f32.convert_u/i32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -191,7 +191,7 @@ define float @f32_convert_u_i32(i32 %x) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result f64
 ; CHECK-NEXT: .local i32, f64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f64.convert_s/i32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -205,7 +205,7 @@ define double @f64_convert_s_i32(i32 %x) {
 ; CHECK-NEXT: .param i32
 ; CHECK-NEXT: .result f64
 ; CHECK-NEXT: .local i32, f64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f64.convert_u/i32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -219,7 +219,7 @@ define double @f64_convert_u_i32(i32 %x) {
 ; CHECK-NEXT: .param i64
 ; CHECK-NEXT: .result f32
 ; CHECK-NEXT: .local i64, f32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f32.convert_s/i64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -233,7 +233,7 @@ define float @f32_convert_s_i64(i64 %x) {
 ; CHECK-NEXT: .param i64
 ; CHECK-NEXT: .result f32
 ; CHECK-NEXT: .local i64, f32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f32.convert_u/i64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -247,7 +247,7 @@ define float @f32_convert_u_i64(i64 %x) {
 ; CHECK-NEXT: .param i64
 ; CHECK-NEXT: .result f64
 ; CHECK-NEXT: .local i64, f64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f64.convert_s/i64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -261,7 +261,7 @@ define double @f64_convert_s_i64(i64 %x) {
 ; CHECK-NEXT: .param i64
 ; CHECK-NEXT: .result f64
 ; CHECK-NEXT: .local i64, f64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f64.convert_u/i64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -275,7 +275,7 @@ define double @f64_convert_u_i64(i64 %x) {
 ; CHECK-NEXT: .param f32
 ; CHECK-NEXT: .result f64
 ; CHECK-NEXT: .local f32, f64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f64.promote/f32 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -289,7 +289,7 @@ define double @f64_promote_f32(float %x) {
 ; CHECK-NEXT: .param f64
 ; CHECK-NEXT: .result f32
 ; CHECK-NEXT: .local f64, f32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f32.demote/f64 push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}

--- a/test/CodeGen/WebAssembly/f32.ll
+++ b/test/CodeGen/WebAssembly/f32.ll
@@ -19,11 +19,11 @@ declare float @llvm.rint.f32(float)
 ; CHECK-NEXT: .param f32{{$}}
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local f32, f32, f32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: add push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: f32.add push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define float @fadd32(float %x, float %y) {
@@ -32,7 +32,7 @@ define float @fadd32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: fsub32:
-; CHECK: sub push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.sub push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define float @fsub32(float %x, float %y) {
   %a = fsub float %x, %y
@@ -40,7 +40,7 @@ define float @fsub32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: fmul32:
-; CHECK: mul push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.mul push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define float @fmul32(float %x, float %y) {
   %a = fmul float %x, %y
@@ -48,7 +48,7 @@ define float @fmul32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: fdiv32:
-; CHECK: div push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.div push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define float @fdiv32(float %x, float %y) {
   %a = fdiv float %x, %y
@@ -56,7 +56,7 @@ define float @fdiv32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: fabs32:
-; CHECK: abs push, (get_local 1){{$}}
+; CHECK: f32.abs push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @fabs32(float %x) {
   %a = call float @llvm.fabs.f32(float %x)
@@ -64,7 +64,7 @@ define float @fabs32(float %x) {
 }
 
 ; CHECK-LABEL: fneg32:
-; CHECK: neg push, (get_local 1){{$}}
+; CHECK: f32.neg push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @fneg32(float %x) {
   %a = fsub float -0., %x
@@ -72,7 +72,7 @@ define float @fneg32(float %x) {
 }
 
 ; CHECK-LABEL: copysign32:
-; CHECK: copysign push, (get_local 3), (get_local 2){{$}}
+; CHECK: f32.copysign push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define float @copysign32(float %x, float %y) {
   %a = call float @llvm.copysign.f32(float %x, float %y)
@@ -80,7 +80,7 @@ define float @copysign32(float %x, float %y) {
 }
 
 ; CHECK-LABEL: sqrt32:
-; CHECK: sqrt push, (get_local 1){{$}}
+; CHECK: f32.sqrt push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @sqrt32(float %x) {
   %a = call float @llvm.sqrt.f32(float %x)
@@ -88,7 +88,7 @@ define float @sqrt32(float %x) {
 }
 
 ; CHECK-LABEL: ceil32:
-; CHECK: ceil push, (get_local 1){{$}}
+; CHECK: f32.ceil push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @ceil32(float %x) {
   %a = call float @llvm.ceil.f32(float %x)
@@ -96,7 +96,7 @@ define float @ceil32(float %x) {
 }
 
 ; CHECK-LABEL: floor32:
-; CHECK: floor push, (get_local 1){{$}}
+; CHECK: f32.floor push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @floor32(float %x) {
   %a = call float @llvm.floor.f32(float %x)
@@ -104,7 +104,7 @@ define float @floor32(float %x) {
 }
 
 ; CHECK-LABEL: trunc32:
-; CHECK: trunc push, (get_local 1){{$}}
+; CHECK: f32.trunc push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @trunc32(float %x) {
   %a = call float @llvm.trunc.f32(float %x)
@@ -112,7 +112,7 @@ define float @trunc32(float %x) {
 }
 
 ; CHECK-LABEL: nearest32:
-; CHECK: nearest push, (get_local 1){{$}}
+; CHECK: f32.nearest push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @nearest32(float %x) {
   %a = call float @llvm.nearbyint.f32(float %x)
@@ -120,7 +120,7 @@ define float @nearest32(float %x) {
 }
 
 ; CHECK-LABEL: nearest32_via_rint:
-; CHECK: nearest push, (get_local 1){{$}}
+; CHECK: f32.nearest push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define float @nearest32_via_rint(float %x) {
   %a = call float @llvm.rint.f32(float %x)

--- a/test/CodeGen/WebAssembly/f64.ll
+++ b/test/CodeGen/WebAssembly/f64.ll
@@ -19,11 +19,11 @@ declare double @llvm.rint.f64(double)
 ; CHECK-NEXT: .param f64{{$}}
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local f64, f64, f64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: add push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: f64.add push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define double @fadd64(double %x, double %y) {
@@ -32,7 +32,7 @@ define double @fadd64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: fsub64:
-; CHECK: sub push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.sub push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define double @fsub64(double %x, double %y) {
   %a = fsub double %x, %y
@@ -40,7 +40,7 @@ define double @fsub64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: fmul64:
-; CHECK: mul push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.mul push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define double @fmul64(double %x, double %y) {
   %a = fmul double %x, %y
@@ -48,7 +48,7 @@ define double @fmul64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: fdiv64:
-; CHECK: div push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.div push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define double @fdiv64(double %x, double %y) {
   %a = fdiv double %x, %y
@@ -56,7 +56,7 @@ define double @fdiv64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: fabs64:
-; CHECK: abs push, (get_local 1){{$}}
+; CHECK: f64.abs push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @fabs64(double %x) {
   %a = call double @llvm.fabs.f64(double %x)
@@ -64,7 +64,7 @@ define double @fabs64(double %x) {
 }
 
 ; CHECK-LABEL: fneg64:
-; CHECK: neg push, (get_local 1){{$}}
+; CHECK: f64.neg push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @fneg64(double %x) {
   %a = fsub double -0., %x
@@ -72,7 +72,7 @@ define double @fneg64(double %x) {
 }
 
 ; CHECK-LABEL: copysign64:
-; CHECK: copysign push, (get_local 3), (get_local 2){{$}}
+; CHECK: f64.copysign push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 define double @copysign64(double %x, double %y) {
   %a = call double @llvm.copysign.f64(double %x, double %y)
@@ -80,7 +80,7 @@ define double @copysign64(double %x, double %y) {
 }
 
 ; CHECK-LABEL: sqrt64:
-; CHECK: sqrt push, (get_local 1){{$}}
+; CHECK: f64.sqrt push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @sqrt64(double %x) {
   %a = call double @llvm.sqrt.f64(double %x)
@@ -88,7 +88,7 @@ define double @sqrt64(double %x) {
 }
 
 ; CHECK-LABEL: ceil64:
-; CHECK: ceil push, (get_local 1){{$}}
+; CHECK: f64.ceil push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @ceil64(double %x) {
   %a = call double @llvm.ceil.f64(double %x)
@@ -96,7 +96,7 @@ define double @ceil64(double %x) {
 }
 
 ; CHECK-LABEL: floor64:
-; CHECK: floor push, (get_local 1){{$}}
+; CHECK: f64.floor push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @floor64(double %x) {
   %a = call double @llvm.floor.f64(double %x)
@@ -104,7 +104,7 @@ define double @floor64(double %x) {
 }
 
 ; CHECK-LABEL: trunc64:
-; CHECK: trunc push, (get_local 1){{$}}
+; CHECK: f64.trunc push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @trunc64(double %x) {
   %a = call double @llvm.trunc.f64(double %x)
@@ -112,7 +112,7 @@ define double @trunc64(double %x) {
 }
 
 ; CHECK-LABEL: nearest64:
-; CHECK: nearest push, (get_local 1){{$}}
+; CHECK: f64.nearest push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @nearest64(double %x) {
   %a = call double @llvm.nearbyint.f64(double %x)
@@ -120,7 +120,7 @@ define double @nearest64(double %x) {
 }
 
 ; CHECK-LABEL: nearest64_via_rint:
-; CHECK: nearest push, (get_local 1){{$}}
+; CHECK: f64.nearest push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 define double @nearest64_via_rint(double %x) {
   %a = call double @llvm.rint.f64(double %x)

--- a/test/CodeGen/WebAssembly/fast-isel.ll
+++ b/test/CodeGen/WebAssembly/fast-isel.ll
@@ -8,13 +8,13 @@ target triple = "wasm32-unknown-unknown"
 ; This tests very minimal fast-isel functionality.
 
 ; CHECK-LABEL: immediate_f32:
-; CHECK: f32.const 0x1.4p1{{$}}
+; CHECK: f32.const push, 0x1.4p1{{$}}
 define float @immediate_f32() {
   ret float 2.5
 }
 
 ; CHECK-LABEL: immediate_f64:
-; CHECK: f64.const 0x1.4p1{{$}}
+; CHECK: f64.const push, 0x1.4p1{{$}}
 define double @immediate_f64() {
   ret double 2.5
 }

--- a/test/CodeGen/WebAssembly/func.ll
+++ b/test/CodeGen/WebAssembly/func.ll
@@ -15,7 +15,7 @@ define void @f0() {
 ; CHECK-LABEL: f1:
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32{{$}}
-; CHECK-NEXT: i32.const 0{{$}}
+; CHECK-NEXT: i32.const push, 0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 ; CHECK: .size f1,
@@ -28,7 +28,7 @@ define i32 @f1() {
 ; CHECK-NEXT: .param f32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32{{$}}
-; CHECK-NEXT: i32.const 0{{$}}
+; CHECK-NEXT: i32.const push, 0{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 ; CHECK: .size f2,

--- a/test/CodeGen/WebAssembly/i32.ll
+++ b/test/CodeGen/WebAssembly/i32.ll
@@ -14,11 +14,11 @@ declare i32 @llvm.ctpop.i32(i32)
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: add push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.add push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @add32(i32 %x, i32 %y) {
@@ -31,11 +31,11 @@ define i32 @add32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: sub push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.sub push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @sub32(i32 %x, i32 %y) {
@@ -48,11 +48,11 @@ define i32 @sub32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: mul push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.mul push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @mul32(i32 %x, i32 %y) {
@@ -65,11 +65,11 @@ define i32 @mul32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: div_s push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.div_s push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @sdiv32(i32 %x, i32 %y) {
@@ -82,11 +82,11 @@ define i32 @sdiv32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: div_u push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.div_u push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @udiv32(i32 %x, i32 %y) {
@@ -99,11 +99,11 @@ define i32 @udiv32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: rem_s push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.rem_s push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @srem32(i32 %x, i32 %y) {
@@ -116,11 +116,11 @@ define i32 @srem32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: rem_u push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.rem_u push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @urem32(i32 %x, i32 %y) {
@@ -133,11 +133,11 @@ define i32 @urem32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: and push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.and push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @and32(i32 %x, i32 %y) {
@@ -150,11 +150,11 @@ define i32 @and32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: or push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.or push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @or32(i32 %x, i32 %y) {
@@ -167,11 +167,11 @@ define i32 @or32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: xor push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.xor push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @xor32(i32 %x, i32 %y) {
@@ -184,11 +184,11 @@ define i32 @xor32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: shl push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.shl push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @shl32(i32 %x, i32 %y) {
@@ -201,11 +201,11 @@ define i32 @shl32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: shr_u push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.shr_u push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @shr32(i32 %x, i32 %y) {
@@ -218,11 +218,11 @@ define i32 @shr32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: shr_s push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i32.shr_s push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i32 @sar32(i32 %x, i32 %y) {
@@ -234,9 +234,9 @@ define i32 @sar32(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: clz push, (get_local 1){{$}}
+; CHECK-NEXT: i32.clz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i32 @clz32(i32 %x) {
@@ -248,9 +248,9 @@ define i32 @clz32(i32 %x) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: clz push, (get_local 1){{$}}
+; CHECK-NEXT: i32.clz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i32 @clz32_zero_undef(i32 %x) {
@@ -262,9 +262,9 @@ define i32 @clz32_zero_undef(i32 %x) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: ctz push, (get_local 1){{$}}
+; CHECK-NEXT: i32.ctz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i32 @ctz32(i32 %x) {
@@ -276,9 +276,9 @@ define i32 @ctz32(i32 %x) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: ctz push, (get_local 1){{$}}
+; CHECK-NEXT: i32.ctz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i32 @ctz32_zero_undef(i32 %x) {
@@ -290,9 +290,9 @@ define i32 @ctz32_zero_undef(i32 %x) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: popcnt push, (get_local 1){{$}}
+; CHECK-NEXT: i32.popcnt push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i32 @popcnt32(i32 %x) {

--- a/test/CodeGen/WebAssembly/i64.ll
+++ b/test/CodeGen/WebAssembly/i64.ll
@@ -14,11 +14,11 @@ declare i64 @llvm.ctpop.i64(i64)
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: add push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.add push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @add64(i64 %x, i64 %y) {
@@ -31,11 +31,11 @@ define i64 @add64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: sub push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.sub push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @sub64(i64 %x, i64 %y) {
@@ -48,11 +48,11 @@ define i64 @sub64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: mul push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.mul push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @mul64(i64 %x, i64 %y) {
@@ -65,11 +65,11 @@ define i64 @mul64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: div_s push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.div_s push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @sdiv64(i64 %x, i64 %y) {
@@ -82,11 +82,11 @@ define i64 @sdiv64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: div_u push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.div_u push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @udiv64(i64 %x, i64 %y) {
@@ -99,11 +99,11 @@ define i64 @udiv64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: rem_s push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.rem_s push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @srem64(i64 %x, i64 %y) {
@@ -116,11 +116,11 @@ define i64 @srem64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: rem_u push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.rem_u push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @urem64(i64 %x, i64 %y) {
@@ -133,11 +133,11 @@ define i64 @urem64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: and push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.and push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @and64(i64 %x, i64 %y) {
@@ -150,11 +150,11 @@ define i64 @and64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: or push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.or push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @or64(i64 %x, i64 %y) {
@@ -167,11 +167,11 @@ define i64 @or64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: xor push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.xor push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @xor64(i64 %x, i64 %y) {
@@ -184,11 +184,11 @@ define i64 @xor64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: shl push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.shl push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @shl64(i64 %x, i64 %y) {
@@ -201,11 +201,11 @@ define i64 @shl64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: shr_u push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.shr_u push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @shr64(i64 %x, i64 %y) {
@@ -218,11 +218,11 @@ define i64 @shr64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64, i64{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
-; CHECK-NEXT: shr_s push, (get_local 3), (get_local 2){{$}}
+; CHECK-NEXT: i64.shr_s push, (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
 ; CHECK-NEXT: return (get_local 4){{$}}
 define i64 @sar64(i64 %x, i64 %y) {
@@ -234,9 +234,9 @@ define i64 @sar64(i64 %x, i64 %y) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: clz push, (get_local 1){{$}}
+; CHECK-NEXT: i64.clz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i64 @clz64(i64 %x) {
@@ -248,9 +248,9 @@ define i64 @clz64(i64 %x) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: clz push, (get_local 1){{$}}
+; CHECK-NEXT: i64.clz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i64 @clz64_zero_undef(i64 %x) {
@@ -262,9 +262,9 @@ define i64 @clz64_zero_undef(i64 %x) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: ctz push, (get_local 1){{$}}
+; CHECK-NEXT: i64.ctz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i64 @ctz64(i64 %x) {
@@ -276,9 +276,9 @@ define i64 @ctz64(i64 %x) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: ctz push, (get_local 1){{$}}
+; CHECK-NEXT: i64.ctz push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i64 @ctz64_zero_undef(i64 %x) {
@@ -290,9 +290,9 @@ define i64 @ctz64_zero_undef(i64 %x) {
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i64, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
-; CHECK-NEXT: popcnt push, (get_local 1){{$}}
+; CHECK-NEXT: i64.popcnt push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i64 @popcnt64(i64 %x) {

--- a/test/CodeGen/WebAssembly/immediates.ll
+++ b/test/CodeGen/WebAssembly/immediates.ll
@@ -8,7 +8,7 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-LABEL: zero_i32:
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i32.const 0{{$}}
+; CHECK-NEXT: i32.const push, 0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i32 @zero_i32() {
@@ -18,7 +18,7 @@ define i32 @zero_i32() {
 ; CHECK-LABEL: one_i32:
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i32.const 1{{$}}
+; CHECK-NEXT: i32.const push, 1{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i32 @one_i32() {
@@ -28,7 +28,7 @@ define i32 @one_i32() {
 ; CHECK-LABEL: max_i32:
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i32.const 2147483647{{$}}
+; CHECK-NEXT: i32.const push, 2147483647{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i32 @max_i32() {
@@ -38,7 +38,7 @@ define i32 @max_i32() {
 ; CHECK-LABEL: min_i32:
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i32.const -2147483648{{$}}
+; CHECK-NEXT: i32.const push, -2147483648{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i32 @min_i32() {
@@ -48,7 +48,7 @@ define i32 @min_i32() {
 ; CHECK-LABEL: zero_i64:
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i64.const 0{{$}}
+; CHECK-NEXT: i64.const push, 0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i64 @zero_i64() {
@@ -58,7 +58,7 @@ define i64 @zero_i64() {
 ; CHECK-LABEL: one_i64:
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i64.const 1{{$}}
+; CHECK-NEXT: i64.const push, 1{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i64 @one_i64() {
@@ -68,7 +68,7 @@ define i64 @one_i64() {
 ; CHECK-LABEL: max_i64:
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i64.const 9223372036854775807{{$}}
+; CHECK-NEXT: i64.const push, 9223372036854775807{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i64 @max_i64() {
@@ -78,7 +78,7 @@ define i64 @max_i64() {
 ; CHECK-LABEL: min_i64:
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: i64.const -9223372036854775808{{$}}
+; CHECK-NEXT: i64.const push, -9223372036854775808{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define i64 @min_i64() {
@@ -88,7 +88,7 @@ define i64 @min_i64() {
 ; CHECK-LABEL: negzero_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const -0x0p0{{$}}
+; CHECK-NEXT: f32.const push, -0x0p0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @negzero_f32() {
@@ -98,7 +98,7 @@ define float @negzero_f32() {
 ; CHECK-LABEL: zero_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const 0x0p0{{$}}
+; CHECK-NEXT: f32.const push, 0x0p0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @zero_f32() {
@@ -108,7 +108,7 @@ define float @zero_f32() {
 ; CHECK-LABEL: one_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const 0x1p0{{$}}
+; CHECK-NEXT: f32.const push, 0x1p0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @one_f32() {
@@ -118,7 +118,7 @@ define float @one_f32() {
 ; CHECK-LABEL: two_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const 0x1p1{{$}}
+; CHECK-NEXT: f32.const push, 0x1p1{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @two_f32() {
@@ -128,7 +128,7 @@ define float @two_f32() {
 ; CHECK-LABEL: nan_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const nan
+; CHECK-NEXT: f32.const push, nan
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @nan_f32() {
@@ -138,7 +138,7 @@ define float @nan_f32() {
 ; CHECK-LABEL: negnan_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const -nan
+; CHECK-NEXT: f32.const push, -nan
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @negnan_f32() {
@@ -148,7 +148,7 @@ define float @negnan_f32() {
 ; CHECK-LABEL: inf_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const infinity
+; CHECK-NEXT: f32.const push, infinity
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @inf_f32() {
@@ -158,7 +158,7 @@ define float @inf_f32() {
 ; CHECK-LABEL: neginf_f32:
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f32.const -infinity
+; CHECK-NEXT: f32.const push, -infinity
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define float @neginf_f32() {
@@ -168,7 +168,7 @@ define float @neginf_f32() {
 ; CHECK-LABEL: negzero_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const -0x0p0{{$}}
+; CHECK-NEXT: f64.const push, -0x0p0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @negzero_f64() {
@@ -178,7 +178,7 @@ define double @negzero_f64() {
 ; CHECK-LABEL: zero_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const 0x0p0{{$}}
+; CHECK-NEXT: f64.const push, 0x0p0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @zero_f64() {
@@ -188,7 +188,7 @@ define double @zero_f64() {
 ; CHECK-LABEL: one_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const 0x1p0{{$}}
+; CHECK-NEXT: f64.const push, 0x1p0{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @one_f64() {
@@ -198,7 +198,7 @@ define double @one_f64() {
 ; CHECK-LABEL: two_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const 0x1p1{{$}}
+; CHECK-NEXT: f64.const push, 0x1p1{{$}}
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @two_f64() {
@@ -208,7 +208,7 @@ define double @two_f64() {
 ; CHECK-LABEL: nan_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const nan
+; CHECK-NEXT: f64.const push, nan
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @nan_f64() {
@@ -218,7 +218,7 @@ define double @nan_f64() {
 ; CHECK-LABEL: negnan_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const -nan
+; CHECK-NEXT: f64.const push, -nan
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @negnan_f64() {
@@ -228,7 +228,7 @@ define double @negnan_f64() {
 ; CHECK-LABEL: inf_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const infinity
+; CHECK-NEXT: f64.const push, infinity
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @inf_f64() {
@@ -238,7 +238,7 @@ define double @inf_f64() {
 ; CHECK-LABEL: neginf_f64:
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local
-; CHECK-NEXT: f64.const -infinity
+; CHECK-NEXT: f64.const push, -infinity
 ; CHECK-NEXT: set_local 0, pop{{$}}
 ; CHECK-NEXT: return (get_local 0){{$}}
 define double @neginf_f64() {

--- a/test/CodeGen/WebAssembly/load-store-i1.ll
+++ b/test/CodeGen/WebAssembly/load-store-i1.ll
@@ -18,7 +18,7 @@ define i32 @load_u_i1_i32(i1* %p) {
 ; CHECK-LABEL: load_s_i1_i32:
 ; CHECK:      i32.load8_u push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: i32.const 31{{$}}
+; CHECK-NEXT: i32.const push, 31{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
 ; CHECK-NEXT: shl push, (get_local 2), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
@@ -44,7 +44,7 @@ define i64 @load_u_i1_i64(i1* %p) {
 ; CHECK-LABEL: load_s_i1_i64:
 ; CHECK:      i64.load8_u push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: i64.const 63{{$}}
+; CHECK-NEXT: i64.const push, 63{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
 ; CHECK-NEXT: shl push, (get_local 2), (get_local 3){{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
@@ -58,9 +58,9 @@ define i64 @load_s_i1_i64(i1* %p) {
 }
 
 ; CHECK-LABEL: store_i32_i1:
-; CHECK:      i32.const 1{{$}}
+; CHECK:      i32.const push, 1{{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: and push, (get_local 3), (get_local 4){{$}}
+; CHECK-NEXT: i32.and push, (get_local 3), (get_local 4){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
 ; CHECK-NEXT: i32.store8 (get_local 2), (get_local 5){{$}}
 define void @store_i32_i1(i1* %p, i32 %v) {
@@ -70,9 +70,9 @@ define void @store_i32_i1(i1* %p, i32 %v) {
 }
 
 ; CHECK-LABEL: store_i64_i1:
-; CHECK:      i64.const 1{{$}}
+; CHECK:      i64.const push, 1{{$}}
 ; CHECK-NEXT: set_local 4, pop{{$}}
-; CHECK-NEXT: and push, (get_local 3), (get_local 4){{$}}
+; CHECK-NEXT: i64.and push, (get_local 3), (get_local 4){{$}}
 ; CHECK-NEXT: set_local 5, pop{{$}}
 ; CHECK-NEXT: i64.store8 (get_local 2), (get_local 5){{$}}
 define void @store_i64_i1(i1* %p, i64 %v) {

--- a/test/CodeGen/WebAssembly/load.ll
+++ b/test/CodeGen/WebAssembly/load.ll
@@ -9,7 +9,7 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32, i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i32.load push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -23,7 +23,7 @@ define i32 @ldi32(i32 *%p) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i64{{$}}
 ; CHECK-NEXT: .local i32, i64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: i64.load push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -37,7 +37,7 @@ define i64 @ldi64(i64 *%p) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result f32{{$}}
 ; CHECK-NEXT: .local i32, f32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f32.load push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
@@ -51,7 +51,7 @@ define float @ldf32(float *%p) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result f64{{$}}
 ; CHECK-NEXT: .local i32, f64{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 1, pop{{$}}
 ; CHECK-NEXT: f64.load push, (get_local 1){{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}

--- a/test/CodeGen/WebAssembly/phi.ll
+++ b/test/CodeGen/WebAssembly/phi.ll
@@ -8,7 +8,7 @@ target triple = "wasm32-unknown-unknown"
 ; Basic phi triangle.
 
 ; CHECK-LABEL: test0:
-; CHECK: get_local 0{{$}}
+; CHECK: get_local push, 0{{$}}
 ; CHECK: set_local [[REG:.*]], pop
 ; CHECK: div_s push, (get_local [[REG]]), {{.*}}
 ; CHECK: set_local [[REG]], pop
@@ -29,9 +29,9 @@ done:
 
 ; CHECK-LABEL: test1:
 ; CHECK: BB1_1:
-; CHECK: get_local [[REG1:.*]]
+; CHECK: get_local push, [[REG1:.*]]
 ; CHECK: set_local [[REG0:.*]], pop
-; CHECK: get_local [[REG2:.*]]
+; CHECK: get_local push, [[REG2:.*]]
 ; CHECK: set_local [[REG1]], pop
 ; CHECK: [[REG0]]
 ; CHECK: set_local [[REG2]], pop

--- a/test/CodeGen/WebAssembly/select.ll
+++ b/test/CodeGen/WebAssembly/select.ll
@@ -7,9 +7,9 @@ target datalayout = "e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-unknown"
 
 ; CHECK-LABEL: select_i32:
-; CHECK: get_local 1
+; CHECK: get_local push, 1
 ; CHECK: set_local [[LOCAL_B:[0-9]]]
-; CHECK: get_local 0
+; CHECK: get_local push, 0
 ; CHECK: set_local [[LOCAL_A:[0-9]]]
 ; CHECK: i32.eq push, (get_local 5), (get_local 6)
 ; CHECK: set_local 7, pop
@@ -21,9 +21,9 @@ define i32 @select_i32(i32 %a, i32 %b, i32 %cond) {
 }
 
 ; CHECK-LABEL: select_i64:
-; CHECK: get_local 1
+; CHECK: get_local push, 1
 ; CHECK: set_local [[LOCAL_B:[0-9]]]
-; CHECK: get_local 0
+; CHECK: get_local push, 0
 ; CHECK: set_local [[LOCAL_A:[0-9]]]
 ; CHECK: i32.eq push, (get_local 5), (get_local 6)
 ; CHECK: set_local 7, pop
@@ -35,9 +35,9 @@ define i64 @select_i64(i64 %a, i64 %b, i32 %cond) {
 }
 
 ; CHECK-LABEL: select_f32:
-; CHECK: get_local 1
+; CHECK: get_local push, 1
 ; CHECK: set_local [[LOCAL_B:[0-9]]]
-; CHECK: get_local 0
+; CHECK: get_local push, 0
 ; CHECK: set_local [[LOCAL_A:[0-9]]]
 ; CHECK: i32.eq push, (get_local 5), (get_local 6)
 ; CHECK: set_local 7, pop
@@ -49,9 +49,9 @@ define float @select_f32(float %a, float %b, i32 %cond) {
 }
 
 ; CHECK-LABEL: select_f64:
-; CHECK: get_local 1
+; CHECK: get_local push, 1
 ; CHECK: set_local [[LOCAL_B:[0-9]]]
-; CHECK: get_local 0
+; CHECK: get_local push, 0
 ; CHECK: set_local [[LOCAL_A:[0-9]]]
 ; CHECK: i32.eq push, (get_local 5), (get_local 6)
 ; CHECK: set_local 7, pop

--- a/test/CodeGen/WebAssembly/store.ll
+++ b/test/CodeGen/WebAssembly/store.ll
@@ -9,9 +9,9 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .local i32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
 ; CHECK-NEXT: i32.store (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: return{{$}}
@@ -24,9 +24,9 @@ define void @sti32(i32 *%p, i32 %v) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .param i64{{$}}
 ; CHECK-NEXT: .local i64, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
 ; CHECK-NEXT: i64.store (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: return{{$}}
@@ -39,9 +39,9 @@ define void @sti64(i64 *%p, i64 %v) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .param f32{{$}}
 ; CHECK-NEXT: .local f32, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
 ; CHECK-NEXT: f32.store (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: return{{$}}
@@ -54,9 +54,9 @@ define void @stf32(float *%p, float %v) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .param f64{{$}}
 ; CHECK-NEXT: .local f64, i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 3, pop{{$}}
 ; CHECK-NEXT: f64.store (get_local 3), (get_local 2){{$}}
 ; CHECK-NEXT: return{{$}}

--- a/test/CodeGen/WebAssembly/unused-argument.ll
+++ b/test/CodeGen/WebAssembly/unused-argument.ll
@@ -10,7 +10,7 @@ target triple = "wasm32-unknown-unknown"
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32{{$}}
-; CHECK-NEXT: get_local 1{{$}}
+; CHECK-NEXT: get_local push, 1{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i32 @unused_first(i32 %x, i32 %y) {
@@ -22,7 +22,7 @@ define i32 @unused_first(i32 %x, i32 %y) {
 ; CHECK-NEXT: .param i32{{$}}
 ; CHECK-NEXT: .result i32{{$}}
 ; CHECK-NEXT: .local i32{{$}}
-; CHECK-NEXT: get_local 0{{$}}
+; CHECK-NEXT: get_local push, 0{{$}}
 ; CHECK-NEXT: set_local 2, pop{{$}}
 ; CHECK-NEXT: return (get_local 2){{$}}
 define i32 @unused_second(i32 %x, i32 %y) {

--- a/test/CodeGen/WinEH/wineh-exceptionpointer.ll
+++ b/test/CodeGen/WinEH/wineh-exceptionpointer.ll
@@ -17,7 +17,7 @@ catch.pad:
 catch.body:
   %exn = call i8 addrspace(1)* @llvm.eh.exceptionpointer.p1i8(token %catch)
   %cast_exn = bitcast i8 addrspace(1)* %exn to i32 addrspace(1)*
-  ; CHECK: movq %rax, %rcx
+  ; CHECK: movq %rdx, %rcx
   ; CHECK-NEXT: callq g
   call void @g(i32 addrspace(1)* %cast_exn)
   catchret %catch to label %exit

--- a/test/CodeGen/X86/vector-shuffle-128-v16.ll
+++ b/test/CodeGen/X86/vector-shuffle-128-v16.ll
@@ -1459,3 +1459,175 @@ define <16 x i8> @insert_dup_mem_v16i8_sext_i8(i8* %ptr) {
   %tmp4 = shufflevector <16 x i8> %tmp3, <16 x i8> undef, <16 x i32> zeroinitializer
   ret <16 x i8> %tmp4
 }
+
+define <16 x i8> @insert_dup_elt1_mem_v16i8_i32(i32* %ptr) {
+; SSE2-LABEL: insert_dup_elt1_mem_v16i8_i32:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,1,0,3]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[1,1,1,1,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,5,5,5,5]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt1_mem_v16i8_i32:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt1_mem_v16i8_i32:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt1_mem_v16i8_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt1_mem_v16i8_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastb 1(%rdi), %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 0
+  %tmp2 = bitcast <4 x i32> %tmp1 to <16 x i8>
+  %tmp3 = shufflevector <16 x i8> %tmp2, <16 x i8> undef, <16 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  ret <16 x i8> %tmp3
+}
+
+define <16 x i8> @insert_dup_elt2_mem_v16i8_i32(i32* %ptr) {
+; SSE2-LABEL: insert_dup_elt2_mem_v16i8_i32:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,1,2,1]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[2,2,2,2,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,6,6,6,6]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt2_mem_v16i8_i32:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt2_mem_v16i8_i32:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt2_mem_v16i8_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt2_mem_v16i8_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastb 2(%rdi), %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 0
+  %tmp2 = bitcast <4 x i32> %tmp1 to <16 x i8>
+  %tmp3 = shufflevector <16 x i8> %tmp2, <16 x i8> undef, <16 x i32> <i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2>
+  ret <16 x i8> %tmp3
+}
+
+define <16 x i8> @insert_dup_elt1_mem_v16i8_sext_i8(i8* %ptr) {
+; SSE2-LABEL: insert_dup_elt1_mem_v16i8_sext_i8:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movsbl (%rdi), %eax
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,1,0,3]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[1,1,1,1,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,5,5,5,5]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt1_mem_v16i8_sext_i8:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movsbl (%rdi), %eax
+; SSSE3-NEXT:    movd %eax, %xmm0
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt1_mem_v16i8_sext_i8:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movsbl (%rdi), %eax
+; SSE41-NEXT:    movd %eax, %xmm0
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt1_mem_v16i8_sext_i8:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    movsbl (%rdi), %eax
+; AVX1-NEXT:    vmovd %eax, %xmm0
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt1_mem_v16i8_sext_i8:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    movsbl (%rdi), %eax
+; AVX2-NEXT:    shrl $8, %eax
+; AVX2-NEXT:    vmovd %eax, %xmm0
+; AVX2-NEXT:    vpbroadcastb %xmm0, %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i8, i8* %ptr, align 1
+  %tmp1 = sext i8 %tmp to i32
+  %tmp2 = insertelement <4 x i32> zeroinitializer, i32 %tmp1, i32 0
+  %tmp3 = bitcast <4 x i32> %tmp2 to <16 x i8>
+  %tmp4 = shufflevector <16 x i8> %tmp3, <16 x i8> undef, <16 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  ret <16 x i8> %tmp4
+}
+
+define <16 x i8> @insert_dup_elt2_mem_v16i8_sext_i8(i8* %ptr) {
+; SSE2-LABEL: insert_dup_elt2_mem_v16i8_sext_i8:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movsbl (%rdi), %eax
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,1,2,1]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[2,2,2,2,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,6,6,6,6]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt2_mem_v16i8_sext_i8:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movsbl (%rdi), %eax
+; SSSE3-NEXT:    movd %eax, %xmm0
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt2_mem_v16i8_sext_i8:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movsbl (%rdi), %eax
+; SSE41-NEXT:    movd %eax, %xmm0
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt2_mem_v16i8_sext_i8:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    movsbl (%rdi), %eax
+; AVX1-NEXT:    vmovd %eax, %xmm0
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt2_mem_v16i8_sext_i8:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    movsbl (%rdi), %eax
+; AVX2-NEXT:    shrl $16, %eax
+; AVX2-NEXT:    vmovd %eax, %xmm0
+; AVX2-NEXT:    vpbroadcastb %xmm0, %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i8, i8* %ptr, align 1
+  %tmp1 = sext i8 %tmp to i32
+  %tmp2 = insertelement <4 x i32> zeroinitializer, i32 %tmp1, i32 0
+  %tmp3 = bitcast <4 x i32> %tmp2 to <16 x i8>
+  %tmp4 = shufflevector <16 x i8> %tmp3, <16 x i8> undef, <16 x i32> <i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2>
+  ret <16 x i8> %tmp4
+}

--- a/test/CodeGen/X86/vector-shuffle-128-v8.ll
+++ b/test/CodeGen/X86/vector-shuffle-128-v8.ll
@@ -2228,3 +2228,171 @@ define <8 x i16> @insert_dup_mem_v8i16_sext_i16(i16* %ptr) {
   %tmp4 = shufflevector <8 x i16> %tmp3, <8 x i16> undef, <8 x i32> zeroinitializer
   ret <8 x i16> %tmp4
 }
+
+define <8 x i16> @insert_dup_elt1_mem_v8i16_i32(i32* %ptr) {
+; SSE2-LABEL: insert_dup_elt1_mem_v8i16_i32:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,1,0,3]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[1,1,1,1,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,5,5,5,5]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt1_mem_v8i16_i32:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt1_mem_v8i16_i32:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt1_mem_v8i16_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt1_mem_v8i16_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastw 2(%rdi), %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 0
+  %tmp2 = bitcast <4 x i32> %tmp1 to <8 x i16>
+  %tmp3 = shufflevector <8 x i16> %tmp2, <8 x i16> undef, <8 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  ret <8 x i16> %tmp3
+}
+
+define <8 x i16> @insert_dup_elt3_mem_v8i16_i32(i32* %ptr) {
+; SSE2-LABEL: insert_dup_elt3_mem_v8i16_i32:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,0,1,0]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[3,3,3,3,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,7,7,7,7]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt3_mem_v8i16_i32:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt3_mem_v8i16_i32:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt3_mem_v8i16_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt3_mem_v8i16_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastw 2(%rdi), %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 1
+  %tmp2 = bitcast <4 x i32> %tmp1 to <8 x i16>
+  %tmp3 = shufflevector <8 x i16> %tmp2, <8 x i16> undef, <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+  ret <8 x i16> %tmp3
+}
+
+define <8 x i16> @insert_dup_elt1_mem_v8i16_sext_i16(i16* %ptr) {
+; SSE2-LABEL: insert_dup_elt1_mem_v8i16_sext_i16:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movswl (%rdi), %eax
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,1,0,3]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[1,1,1,1,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,5,5,5,5]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt1_mem_v8i16_sext_i16:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movswl (%rdi), %eax
+; SSSE3-NEXT:    movd %eax, %xmm0
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt1_mem_v8i16_sext_i16:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movswl (%rdi), %eax
+; SSE41-NEXT:    movd %eax, %xmm0
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt1_mem_v8i16_sext_i16:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    movswl (%rdi), %eax
+; AVX1-NEXT:    vmovd %eax, %xmm0
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt1_mem_v8i16_sext_i16:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    movswl (%rdi), %eax
+; AVX2-NEXT:    shrl $16, %eax
+; AVX2-NEXT:    vmovd %eax, %xmm0
+; AVX2-NEXT:    vpbroadcastw %xmm0, %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i16, i16* %ptr, align 2
+  %tmp1 = sext i16 %tmp to i32
+  %tmp2 = insertelement <4 x i32> zeroinitializer, i32 %tmp1, i32 0
+  %tmp3 = bitcast <4 x i32> %tmp2 to <8 x i16>
+  %tmp4 = shufflevector <8 x i16> %tmp3, <8 x i16> undef, <8 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  ret <8 x i16> %tmp4
+}
+
+define <8 x i16> @insert_dup_elt3_mem_v8i16_sext_i16(i16* %ptr) {
+; SSE2-LABEL: insert_dup_elt3_mem_v8i16_sext_i16:
+; SSE2:       # BB#0:
+; SSE2-NEXT:    movswl (%rdi), %eax
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,0,1,0]
+; SSE2-NEXT:    pshuflw {{.*#+}} xmm0 = xmm0[3,3,3,3,4,5,6,7]
+; SSE2-NEXT:    pshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,7,7,7,7]
+; SSE2-NEXT:    retq
+;
+; SSSE3-LABEL: insert_dup_elt3_mem_v8i16_sext_i16:
+; SSSE3:       # BB#0:
+; SSSE3-NEXT:    movswl (%rdi), %eax
+; SSSE3-NEXT:    movd %eax, %xmm0
+; SSSE3-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: insert_dup_elt3_mem_v8i16_sext_i16:
+; SSE41:       # BB#0:
+; SSE41-NEXT:    movswl (%rdi), %eax
+; SSE41-NEXT:    movd %eax, %xmm0
+; SSE41-NEXT:    pshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; SSE41-NEXT:    retq
+;
+; AVX1-LABEL: insert_dup_elt3_mem_v8i16_sext_i16:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    movswl (%rdi), %eax
+; AVX1-NEXT:    vmovd %eax, %xmm0
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt3_mem_v8i16_sext_i16:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    movswl (%rdi), %eax
+; AVX2-NEXT:    shrl $16, %eax
+; AVX2-NEXT:    vmovd %eax, %xmm0
+; AVX2-NEXT:    vpbroadcastw %xmm0, %xmm0
+; AVX2-NEXT:    retq
+  %tmp = load i16, i16* %ptr, align 2
+  %tmp1 = sext i16 %tmp to i32
+  %tmp2 = insertelement <4 x i32> zeroinitializer, i32 %tmp1, i32 1
+  %tmp3 = bitcast <4 x i32> %tmp2 to <8 x i16>
+  %tmp4 = shufflevector <8 x i16> %tmp3, <8 x i16> undef, <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+  ret <8 x i16> %tmp4
+}

--- a/test/CodeGen/X86/vector-shuffle-256-v16.ll
+++ b/test/CodeGen/X86/vector-shuffle-256-v16.ll
@@ -3331,3 +3331,41 @@ define <16 x i16> @insert_dup_mem_v16i16_sext_i16(i16* %ptr) {
   %tmp4 = shufflevector <8 x i16> %tmp3, <8 x i16> undef, <16 x i32> zeroinitializer
   ret <16 x i16> %tmp4
 }
+
+define <16 x i16> @insert_dup_elt1_mem_v16i16_i32(i32* %ptr) #0 {
+; AVX1-LABEL: insert_dup_elt1_mem_v16i16_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt1_mem_v16i16_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastw 2(%rdi), %ymm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 0
+  %tmp2 = bitcast <4 x i32> %tmp1 to <8 x i16>
+  %tmp3 = shufflevector <8 x i16> %tmp2, <8 x i16> undef, <16 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  ret <16 x i16> %tmp3
+}
+
+define <16 x i16> @insert_dup_elt3_mem_v16i16_i32(i32* %ptr) #0 {
+; AVX1-LABEL: insert_dup_elt3_mem_v16i16_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[2,3,2,3,2,3,2,3,2,3,2,3,2,3,2,3]
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt3_mem_v16i16_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastw 2(%rdi), %ymm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 1
+  %tmp2 = bitcast <4 x i32> %tmp1 to <8 x i16>
+  %tmp3 = shufflevector <8 x i16> %tmp2, <8 x i16> undef, <16 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+  ret <16 x i16> %tmp3
+}

--- a/test/CodeGen/X86/vector-shuffle-256-v32.ll
+++ b/test/CodeGen/X86/vector-shuffle-256-v32.ll
@@ -2018,3 +2018,65 @@ define <32 x i8> @insert_dup_mem_v32i8_sext_i8(i8* %ptr) {
   %tmp4 = shufflevector <16 x i8> %tmp3, <16 x i8> undef, <32 x i32> zeroinitializer
   ret <32 x i8> %tmp4
 }
+
+define <32 x i8> @insert_dup_elt1_mem_v32i8_i32(i32* %ptr) {
+; AVX1-LABEL: insert_dup_elt1_mem_v32i8_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt1_mem_v32i8_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastb 1(%rdi), %ymm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 0
+  %tmp2 = bitcast <4 x i32> %tmp1 to <16 x i8>
+  %tmp3 = shufflevector <16 x i8> %tmp2, <16 x i8> undef, <32 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  ret <32 x i8> %tmp3
+}
+
+define <32 x i8> @insert_dup_elt3_mem_v32i8_i32(i32* %ptr) {
+; AVX1-LABEL: insert_dup_elt3_mem_v32i8_i32:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    vmovd {{.*#+}} xmm0 = mem[0],zero,zero,zero
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3]
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt3_mem_v32i8_i32:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    vpbroadcastb 3(%rdi), %ymm0
+; AVX2-NEXT:    retq
+  %tmp = load i32, i32* %ptr, align 4
+  %tmp1 = insertelement <4 x i32> zeroinitializer, i32 %tmp, i32 0
+  %tmp2 = bitcast <4 x i32> %tmp1 to <16 x i8>
+  %tmp3 = shufflevector <16 x i8> %tmp2, <16 x i8> undef, <32 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+  ret <32 x i8> %tmp3
+}
+
+define <32 x i8> @insert_dup_elt1_mem_v32i8_sext_i8(i8* %ptr) {
+; AVX1-LABEL: insert_dup_elt1_mem_v32i8_sext_i8:
+; AVX1:       # BB#0:
+; AVX1-NEXT:    movsbl (%rdi), %eax
+; AVX1-NEXT:    vmovd %eax, %xmm0
+; AVX1-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm0, %ymm0
+; AVX1-NEXT:    retq
+;
+; AVX2-LABEL: insert_dup_elt1_mem_v32i8_sext_i8:
+; AVX2:       # BB#0:
+; AVX2-NEXT:    movsbl (%rdi), %eax
+; AVX2-NEXT:    shrl $8, %eax
+; AVX2-NEXT:    vmovd %eax, %xmm0
+; AVX2-NEXT:    vpbroadcastb %xmm0, %ymm0
+; AVX2-NEXT:    retq
+  %tmp = load i8, i8* %ptr, align 1
+  %tmp1 = sext i8 %tmp to i32
+  %tmp2 = insertelement <4 x i32> zeroinitializer, i32 %tmp1, i32 0
+  %tmp3 = bitcast <4 x i32> %tmp2 to <16 x i8>
+  %tmp4 = shufflevector <16 x i8> %tmp3, <16 x i8> undef, <32 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  ret <32 x i8> %tmp4
+}

--- a/test/Feature/OperandBundles/function-attrs.ll
+++ b/test/Feature/OperandBundles/function-attrs.ll
@@ -1,0 +1,24 @@
+; RUN: opt -S -functionattrs < %s | FileCheck %s
+
+declare void @f_readonly() readonly
+declare void @f_readnone() readnone
+
+define void @test_0(i32* %x) {
+; FunctionAttrs must not infer readonly / readnone for %x
+
+; CHECK-LABEL: define void @test_0(i32* %x) {
+ entry:
+ ; CHECK: call void @f_readonly() [ "foo"(i32* %x) ]
+  call void @f_readonly() [ "foo"(i32* %x) ]
+  ret void
+}
+
+define void @test_1(i32* %x) {
+; FunctionAttrs must not infer readonly / readnone for %x
+
+; CHECK-LABEL: define void @test_1(i32* %x) {
+ entry:
+ ; CHECK: call void @f_readnone() [ "foo"(i32* %x) ]
+  call void @f_readnone() [ "foo"(i32* %x) ]
+  ret void
+}

--- a/test/Transforms/FunctionAttrs/out-of-bounds-iterator-bug.ll
+++ b/test/Transforms/FunctionAttrs/out-of-bounds-iterator-bug.ll
@@ -1,0 +1,30 @@
+; RUN: opt -functionattrs -S < %s | FileCheck %s
+
+; This checks for an iterator wraparound bug in FunctionAttrs.  The previous
+; "incorrect" behavior was inferring readonly for the %x argument in @caller.
+; Inferring readonly for %x *is* actually correct, since @va_func is marked
+; readonly, but FunctionAttrs was inferring readonly for the wrong reasons (and
+; we _need_ the readonly on @va_func to trigger the problematic code path).  It
+; is possible that in the future FunctionAttrs becomes smart enough to infer
+; readonly for %x for the right reasons, and at that point this test will have
+; to be marked invalid.
+
+declare void @llvm.va_start(i8*)
+declare void @llvm.va_end(i8*)
+
+define void @va_func(i32* readonly %b, ...) readonly nounwind {
+; CHECK-LABEL: define void @va_func(i32* nocapture readonly %b, ...)
+ entry:
+  %valist = alloca i8
+  call void @llvm.va_start(i8* %valist)
+  call void @llvm.va_end(i8* %valist)
+  %x = call i32 @caller(i32* %b)
+  ret void
+}
+
+define i32 @caller(i32* %x) {
+; CHECK-LABEL: define i32 @caller(i32* nocapture %x)
+ entry:
+  call void(i32*,...) @va_func(i32* null, i32 0, i32 0, i32 0, i32* %x)
+  ret i32 42
+}

--- a/test/Transforms/InstCombine/token.ll
+++ b/test/Transforms/InstCombine/token.ll
@@ -1,0 +1,97 @@
+; RUN: opt < %s -instcombine -S | FileCheck %s
+target datalayout = "e-m:w-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc18.0.0"
+
+declare i32 @__CxxFrameHandler3(...)
+
+define void @test1() personality i32 (...)* @__CxxFrameHandler3 {
+bb:
+  unreachable
+
+unreachable:
+  %cl = cleanuppad []
+  cleanupret %cl unwind to caller
+}
+
+; CHECK-LABEL: define void @test1(
+; CHECK: unreachable:
+; CHECK:   %cl = cleanuppad []
+; CHECK:   cleanupret %cl unwind to caller
+
+define void @test2(i8 %A, i8 %B) personality i32 (...)* @__CxxFrameHandler3 {
+bb:
+  %X = zext i8 %A to i32
+  invoke void @g(i32 0)
+    to label %cont
+    unwind label %catch
+
+cont:
+  %Y = zext i8 %B to i32
+  invoke void @g(i32 0)
+    to label %unreachable
+    unwind label %catch
+
+catch:
+  %phi = phi i32 [ %X, %bb ], [ %Y, %cont ]
+  %cl = catchpad []
+   to label %doit
+   unwind label %endpad
+
+doit:
+  call void @g(i32 %phi)
+  unreachable
+
+unreachable:
+  unreachable
+
+endpad:
+  catchendpad unwind to caller
+}
+
+; CHECK-LABEL: define void @test2(
+; CHECK:  %X = zext i8 %A to i32
+; CHECK:  %Y = zext i8 %B to i32
+; CHECK:  %phi = phi i32 [ %X, %bb ], [ %Y, %cont ]
+
+define void @test3(i8 %A, i8 %B) personality i32 (...)* @__CxxFrameHandler3 {
+bb:
+  %X = zext i8 %A to i32
+  invoke void @g(i32 0)
+    to label %cont
+    unwind label %catch
+
+cont:
+  %Y = zext i8 %B to i32
+  invoke void @g(i32 0)
+    to label %cont2
+    unwind label %catch
+
+cont2:
+  invoke void @g(i32 0)
+    to label %unreachable
+    unwind label %catch
+
+catch:
+  %phi = phi i32 [ %X, %bb ], [ %Y, %cont ], [ %Y, %cont2 ]
+  %cl = catchpad []
+   to label %doit
+   unwind label %endpad
+
+doit:
+  call void @g(i32 %phi)
+  unreachable
+
+unreachable:
+  unreachable
+
+endpad:
+  catchendpad unwind to caller
+}
+
+; CHECK-LABEL: define void @test3(
+; CHECK:  %X = zext i8 %A to i32
+; CHECK:  %Y = zext i8 %B to i32
+; CHECK:  %phi = phi i32 [ %X, %bb ], [ %Y, %cont ], [ %Y, %cont2 ]
+
+
+declare void @g(i32)

--- a/test/Transforms/TailCallElim/notail.ll
+++ b/test/Transforms/TailCallElim/notail.ll
@@ -1,0 +1,24 @@
+; RUN: opt < %s -tailcallelim -S | FileCheck %s
+
+; CHECK: tail call void @callee0()
+; CHECK: notail call void @callee1()
+
+define void @foo1(i32 %a) {
+entry:
+  %tobool = icmp eq i32 %a, 0
+  br i1 %tobool, label %if.else, label %if.then
+
+if.then:
+  call void @callee0()
+  br label %if.end
+
+if.else:
+  notail call void @callee1()
+  br label %if.end
+
+if.end:
+  ret void
+}
+
+declare void @callee0()
+declare void @callee1()

--- a/tools/llvm-stress/llvm-stress.cpp
+++ b/tools/llvm-stress/llvm-stress.cpp
@@ -666,7 +666,7 @@ static void IntroduceControlFlow(Function *F, Random &R) {
 
   for (auto *Instr : BoolInst) {
     BasicBlock *Curr = Instr->getParent();
-    BasicBlock::iterator Loc = Instr;
+    BasicBlock::iterator Loc = Instr->getIterator();
     BasicBlock *Next = Curr->splitBasicBlock(Loc, "CF");
     Instr->moveBefore(Curr->getTerminator());
     if (Curr != &F->getEntryBlock()) {


### PR DESCRIPTION
This includes r252372 (git commit 84cb8974b), which removes the implicit conversions between ilist/iplist iterators and the iterated node types, and updates our non-upstreamed implicit conversions to explicit ones instead.