### PR TITLE
Annotate GC_TRANSITION_RA opcode as 'mayStore'

### DIFF
--- a/lib/Target/X86/X86InstrCompiler.td
+++ b/lib/Target/X86/X86InstrCompiler.td
@@ -84,7 +84,7 @@ def : Pat<(X86callseq_start timm:$amt1),
 //   STATEPOINT
 // label:
 //   ...
-let usesCustomInserter = 1, Defs = [EFLAGS] in {
+let usesCustomInserter = 1, Defs = [EFLAGS], mayStore=1 in {
 def GC_TRANSITION_RA : I<0, Pseudo, (outs), (ins i8mem:$dst),
                          "#GC_TRANSITION_RA",
                          []>;


### PR DESCRIPTION
The machine verifier complains without this due to the store memopnd we
put on the instruction.