### PR TITLE
Extending MCWinCOFFStreamer to handle relcation in form of general expressions.

### DIFF
--- a/include/llvm/MC/MCStreamer.h
+++ b/include/llvm/MC/MCStreamer.h
@@ -458,6 +458,13 @@ public:
   /// \param Symbol - Symbol the section relative relocation should point to.
   virtual void EmitCOFFSecRel32(MCSymbol const *Symbol);
 
+  /// \brief Emits a COFF section relative relocation in form of an general 
+  /// (arithmetic) expression.
+  ///
+  /// \param Value - Symbol expression the section relative relocation should 
+  /// point to.
+  virtual void EmitCOFFSecRel32Value(MCExpr const *Value);
+
   /// \brief Emit an ELF .size directive.
   ///
   /// This corresponds to an assembler statement such as:

--- a/include/llvm/MC/MCWinCOFFStreamer.h
+++ b/include/llvm/MC/MCWinCOFFStreamer.h
@@ -53,6 +53,7 @@ public:
   void EmitCOFFSafeSEH(MCSymbol const *Symbol) override;
   void EmitCOFFSectionIndex(MCSymbol const *Symbol) override;
   void EmitCOFFSecRel32(MCSymbol const *Symbol) override;
+  void EmitCOFFSecRel32Value(MCExpr const *Value) override;
   void EmitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
                         unsigned ByteAlignment) override;
   void EmitLocalCommonSymbol(MCSymbol *Symbol, uint64_t Size,

--- a/lib/MC/MCStreamer.cpp
+++ b/lib/MC/MCStreamer.cpp
@@ -594,6 +594,9 @@ void MCStreamer::EmitCOFFSectionIndex(MCSymbol const *Symbol) {
 void MCStreamer::EmitCOFFSecRel32(MCSymbol const *Symbol) {
 }
 
+void MCStreamer::EmitCOFFSecRel32Value(MCExpr const *Value) {
+}
+
 /// EmitRawText - If this file is backed by an assembly streamer, this dumps
 /// the specified string in the output .s file.  This capability is
 /// indicated by the hasRawTextSupport() predicate.

--- a/lib/MC/WinCOFFStreamer.cpp
+++ b/lib/MC/WinCOFFStreamer.cpp
@@ -200,9 +200,13 @@ void MCWinCOFFStreamer::EmitCOFFSectionIndex(MCSymbol const *Symbol) {
 }
 
 void MCWinCOFFStreamer::EmitCOFFSecRel32(MCSymbol const *Symbol) {
-  MCDataFragment *DF = getOrCreateDataFragment();
   const MCSymbolRefExpr *SRE = MCSymbolRefExpr::create(Symbol, getContext());
-  MCFixup Fixup = MCFixup::create(DF->getContents().size(), SRE, FK_SecRel_4);
+  EmitCOFFSecRel32Value(SRE);
+}
+
+void MCWinCOFFStreamer::EmitCOFFSecRel32Value(MCExpr const *Value) {
+  MCDataFragment *DF = getOrCreateDataFragment();
+  MCFixup Fixup = MCFixup::create(DF->getContents().size(), Value, FK_SecRel_4);
   DF->getFixups().push_back(Fixup);
   DF->getContents().resize(DF->getContents().size() + 4, 0);
 }


### PR DESCRIPTION
Extending MCWinCOFFStreamer to handle relcation in form of general .

This change is a prerequisite to CoreRT pdb data generation.