### PR TITLE
LLJIT: Add accessor utilities

### DIFF
--- a/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -89,6 +89,10 @@ public:
   /// Returns a reference to the ObjLinkingLayer
   RTDyldObjectLinkingLayer2 &getObjLinkingLayer() { return ObjLinkingLayer; }
 
+  TargetMachine* getTargetMachine() const { return TM; }
+
+  const DataLayout& getDataLayout() const { return DL; }
+
 protected:
   LLJIT(std::unique_ptr<ExecutionSession> ES, std::unique_ptr<TargetMachine> TM,
         DataLayout DL);


### PR DESCRIPTION
This is helpful for setting the LLVM module to be conformant with the default in the LLJIT instance